### PR TITLE
Hide full framework tests when on .NET Core

### DIFF
--- a/FrameworkTests/FrameworkTestFixture.cs
+++ b/FrameworkTests/FrameworkTestFixture.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
-
+#if Is_Windows
 namespace FrameworkTests
 {
     [TestFixture]
@@ -85,3 +85,4 @@ namespace FrameworkTests
         }
     }
 }
+#endif

--- a/FrameworkTests/FrameworkTests.csproj
+++ b/FrameworkTests/FrameworkTests.csproj
@@ -12,6 +12,9 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <DefineConstants>Is_Windows</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
These tests currently fail against .NET Core, as they're full framework tests this will only discover them when compiling against the full framework.