### PR TITLE
Exclude non-project items

### DIFF
--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -67,15 +67,25 @@ namespace Buildalyzer
 
         private void GetProjectsInSolution(string solutionPath)
         {
+            var supportedType = new[]
+            {
+                SolutionProjectType.KnownToBeMSBuildFormat,
+                SolutionProjectType.WebProject
+            };
+
             SolutionFile solution = SolutionFile.Parse(solutionPath);
             foreach(ProjectInSolution project in solution.ProjectsInOrder)
             {
+                if (!supportedType.Contains(project.ProjectType))
+                    continue;
                 GetProject(project.AbsolutePath);
             }
         }
         
         public ProjectAnalyzer GetProject(string projectPath)
         {
+            // Normalise as .sln uses backslash regardless of OS the sln is created on
+            projectPath = projectPath.Replace('\\', Path.DirectorySeparatorChar);
             projectPath = ValidatePath(projectPath);
             if (_projects.TryGetValue(projectPath, out ProjectAnalyzer project))
             {

--- a/tests/NetCoreTests/NetCoreTestFixture.cs
+++ b/tests/NetCoreTests/NetCoreTestFixture.cs
@@ -81,14 +81,28 @@ namespace NetCoreTests
             // Then
             manager.Projects.Keys.ShouldBe(_projectFiles.Select(x => GetProjectPath(x)), true);
         }
+        
+        [Test]
+        public void IgnoreSolutionItemsThatAreNotProjects()
+        {
+            // Given / When
+            var manager = new AnalyzerManager(GetProjectPath("TestProjects.sln"));
+            
+            // Then
+            manager.Projects.Any(x => x.Value.ProjectPath.Contains("TestEmptySolutionFolder")).ShouldBeFalse();
+        }
 
         private ProjectAnalyzer GetProjectAnalyzer(string projectFile, StringBuilder log) =>
             new AnalyzerManager(log).GetProject(GetProjectPath(projectFile));
 
-        private string GetProjectPath(string file) =>
-            Path.GetFullPath(
+        private static string GetProjectPath(string file)
+        {
+            var path = Path.GetFullPath(
                 Path.Combine(
                     Path.GetDirectoryName(typeof(NetCoreTestFixture).Assembly.Location),
                     @"..\..\..\..\projects\" + file));
+
+            return path.Replace('\\', Path.DirectorySeparatorChar);
+        }
     }
 }

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNetStandardProject", "SdkNetStandardProject\SdkNetStandardProject.csproj", "{016713D9-B665-4272-9980-148801A9B88F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNetStandardProjectImport", "SdkNetStandardProjectImport\SdkNetStandardProjectImport.csproj", "{203CC213-E0F1-4FC0-9EA6-4FFA50CDA629}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestEmptySolutionFolder", "TestEmptySolutionFolder", "{2D087EE8-ECCB-41D6-809D-D95B58B37F26}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This change ensures that only projects are added to the project collection. [Here's a list](https://msdn.microsoft.com/en-us/library/microsoft.build.construction.solutionprojecttype.aspx) of all of the potential types, this change only includes `KnownToBeMSBuildFormat` and `WebProject`.