### PR TITLE
increase timeout to get the dotnet --info output from 1 to 4 seconds

### DIFF
--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -64,7 +64,7 @@ namespace Buildalyzer.Environment
                 sw.Start();
                 while (!process.HasExited)
                 {
-                    if (sw.ElapsedMilliseconds > 1000)
+                    if (sw.ElapsedMilliseconds > 4000)
                     {
                         break;
                     }


### PR DESCRIPTION
Completely anecdotal but this fixed our `TeamCity` builds that were failing on this.