### PR TITLE
Add tests for PackageReference projects

### DIFF
--- a/Buildalyzer.sln
+++ b/Buildalyzer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildalyzer", "src\Buildalyzer\Buildalyzer.csproj", "{252BD05D-80E4-4AE9-AE83-98B8D01CA30C}"
 EndProject
@@ -31,7 +31,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "projects", "projects", "{91
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkFrameworkProject", "tests\projects\SdkFrameworkProject\SdkFrameworkProject.csproj", "{E25BB2EE-960A-4541-B06B-32320E88A8BB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SdkMultiTargetingProject", "tests\projects\SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", "{D5038575-5855-4A10-8BE0-FEC716AC91F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkMultiTargetingProject", "tests\projects\SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", "{D5038575-5855-4A10-8BE0-FEC716AC91F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProjectWithPackageReference", "tests\projects\LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", "{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,10 @@ Global
 		{D5038575-5855-4A10-8BE0-FEC716AC91F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5038575-5855-4A10-8BE0-FEC716AC91F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5038575-5855-4A10-8BE0-FEC716AC91F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +114,7 @@ Global
 		{91B03910-3786-46F8-9CEE-5864CB65DA41} = {2D6F1622-8D17-4D49-A9D1-E4AEAFE99370}
 		{E25BB2EE-960A-4541-B06B-32320E88A8BB} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
 		{D5038575-5855-4A10-8BE0-FEC716AC91F0} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1716863C-E9E2-4074-B557-E38CEB3B5C84}

--- a/tests/FrameworkTests/FrameworkTestFixture.cs
+++ b/tests/FrameworkTests/FrameworkTestFixture.cs
@@ -22,6 +22,7 @@ namespace FrameworkTests
         {
             @"LegacyFrameworkProject\LegacyFrameworkProject.csproj",
             @"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj",
+            @"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj",
             @"SdkNetCoreProject\SdkNetCoreProject.csproj",
             @"SdkNetStandardProject\SdkNetStandardProject.csproj",
             @"SdkNetCoreProjectImport\SdkNetCoreProjectImport.csproj",
@@ -89,6 +90,24 @@ namespace FrameworkTests
 
             // Then
             sourceFiles.ShouldContain(x => x.EndsWith("Class1.cs"), log.ToString());
+        }
+
+        [TestCaseSource(nameof(_projectFiles))]
+        public void GetsReferences(string projectFile)
+        {
+            // Given
+            StringWriter log = new StringWriter();
+            ProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+
+            // When
+            IReadOnlyList<string> references = analyzer.GetReferences();
+
+            // Then
+            references.ShouldContain(x => x.EndsWith("mscorlib.dll"), log.ToString());
+            if (projectFile.Contains("PackageReference"))
+            {
+                references.ShouldContain(x => x.EndsWith("Newtonsoft.Json.dll"), log.ToString());
+            }
         }
 
         [Test]

--- a/tests/FrameworkTests/FrameworkTests.csproj
+++ b/tests/FrameworkTests/FrameworkTests.csproj
@@ -50,28 +50,28 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Options, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.3.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.2.8.3\lib\net451\Shouldly.dll</HintPath>
+      <HintPath>..\..\packages\Shouldly.2.8.3\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -80,29 +80,29 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.FileSystem">
-      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.FileSystem.Primitives">
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime">
-      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <HintPath>..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.4.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.4.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices">
-      <HintPath>..\packages\System.Runtime.InteropServices.4.3.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+      <HintPath>..\..\packages\System.Runtime.InteropServices.4.3.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading.Thread">

--- a/tests/FrameworkTests/app.config
+++ b/tests/FrameworkTests/app.config
@@ -15,6 +15,14 @@
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>

--- a/tests/NetCoreTests/NetCoreTestFixture.cs
+++ b/tests/NetCoreTests/NetCoreTestFixture.cs
@@ -21,6 +21,7 @@ namespace NetCoreTests
 #if Is_Windows
             @"LegacyFrameworkProject\LegacyFrameworkProject.csproj",
             @"LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj",
+            @"LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj",
             @"SdkFrameworkProject\SdkFrameworkProject.csproj",
 #endif
             @"SdkNetCoreProject\SdkNetCoreProject.csproj",
@@ -89,6 +90,24 @@ namespace NetCoreTests
 
             // Then
             sourceFiles.ShouldContain(x => x.EndsWith("Class1.cs"), log.ToString());
+        }
+
+        [TestCaseSource(nameof(_projectFiles))]
+        public void GetsReferences(string projectFile)
+        {
+            // Given
+            StringWriter log = new StringWriter();
+            ProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+
+            // When
+            IReadOnlyList<string> references = analyzer.GetReferences();
+
+            // Then
+            references.ShouldContain(x => x.EndsWith("mscorlib.dll"), log.ToString());
+            if (projectFile.Contains("PackageReference"))
+            {
+                references.ShouldContain(x => x.EndsWith("Newtonsoft.Json.dll"), log.ToString());
+            }
         }
 
         [Test]

--- a/tests/projects/LegacyFrameworkProjectWithPackageReference/Class1.cs
+++ b/tests/projects/LegacyFrameworkProjectWithPackageReference/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LegacyFrameworkProjectWithPackageReference
+{
+    class Class1
+    {
+    }
+}

--- a/tests/projects/LegacyFrameworkProjectWithPackageReference/LegacyFrameworkProjectWithPackageReference.csproj
+++ b/tests/projects/LegacyFrameworkProjectWithPackageReference/LegacyFrameworkProjectWithPackageReference.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LegacyFrameworkProjectWithPackageReference</RootNamespace>
+    <AssemblyName>LegacyFrameworkProjectWithPackageReference</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>10.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LegacyFrameworkProject\LegacyFrameworkProject.csproj">
+      <Project>{36ed2b9d-2fc2-4725-9bc2-53cabf113477}</Project>
+      <Name>LegacyFrameworkProject</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/projects/LegacyFrameworkProjectWithPackageReference/Properties/AssemblyInfo.cs
+++ b/tests/projects/LegacyFrameworkProjectWithPackageReference/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LegacyFrameworkProjectWithPackageReference")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LegacyFrameworkProjectWithPackageReference")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd3445e2-a34a-4d87-9e8a-5081cbfa2f86")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProject", "LegacyFrameworkProject\LegacyFrameworkProject.csproj", "{36ED2B9D-2FC2-4725-9BC2-53CABF113477}"
 EndProject
@@ -18,6 +18,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestEmptySolutionFolder", "TestEmptySolutionFolder", "{2D087EE8-ECCB-41D6-809D-D95B58B37F26}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkFrameworkProject", "SdkFrameworkProject\SdkFrameworkProject.csproj", "{7D74ABB0-2BF5-48EF-B1AE-A32B722276F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProjectWithPackageReference", "LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", "{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{7D74ABB0-2BF5-48EF-B1AE-A32B722276F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D74ABB0-2BF5-48EF-B1AE-A32B722276F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D74ABB0-2BF5-48EF-B1AE-A32B722276F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds tests for projects that use PackageReference instead of packages.config. Some of them are failing as noted in daveaglick/Buildalyzer#33.