### PR TITLE
Changed MSBuild Project construction to set project file path

### DIFF
--- a/Buildalyzer.sln
+++ b/Buildalyzer.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkMultiTargetingProject", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProjectWithPackageReference", "tests\projects\LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", "{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SdkProjectWithImportedProps", "tests\projects\SdkProjectWithImportedProps\SdkProjectWithImportedProps.csproj", "{99080E4E-D2E6-4764-84E8-4EABCF449963}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,10 @@ Global
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99080E4E-D2E6-4764-84E8-4EABCF449963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99080E4E-D2E6-4764-84E8-4EABCF449963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99080E4E-D2E6-4764-84E8-4EABCF449963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99080E4E-D2E6-4764-84E8-4EABCF449963}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +121,7 @@ Global
 		{E25BB2EE-960A-4541-B06B-32320E88A8BB} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
 		{D5038575-5855-4A10-8BE0-FEC716AC91F0} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
+		{99080E4E-D2E6-4764-84E8-4EABCF449963} = {91B03910-3786-46F8-9CEE-5864CB65DA41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1716863C-E9E2-4074-B557-E38CEB3B5C84}

--- a/tests/FrameworkTests/FrameworkTestFixture.cs
+++ b/tests/FrameworkTests/FrameworkTestFixture.cs
@@ -28,6 +28,7 @@ namespace FrameworkTests
             @"SdkNetCoreProjectImport\SdkNetCoreProjectImport.csproj",
             @"SdkNetStandardProjectImport\SdkNetStandardProjectImport.csproj",
             @"SdkFrameworkProject\SdkFrameworkProject.csproj",
+            @"SdkProjectWithImportedProps\SdkProjectWithImportedProps.csproj",
             //@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj"
         };
 
@@ -133,7 +134,7 @@ namespace FrameworkTests
             _projectFiles.Select(x => GetProjectPath(x)).ShouldBeSubsetOf(manager.Projects.Keys, log.ToString());
         }
 
-        private ProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log) => 
+        private ProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log) =>
             new AnalyzerManager(new AnalyzerManagerOptions
             {
                 LogWriter = log

--- a/tests/NetCoreTests/NetCoreTestFixture.cs
+++ b/tests/NetCoreTests/NetCoreTestFixture.cs
@@ -28,6 +28,7 @@ namespace NetCoreTests
             @"SdkNetCoreProjectImport\SdkNetCoreProjectImport.csproj",
             @"SdkNetStandardProject\SdkNetStandardProject.csproj",
             @"SdkNetStandardProjectImport\SdkNetStandardProjectImport.csproj",
+            @"SdkProjectWithImportedProps\SdkProjectWithImportedProps.csproj",
             //@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj"  // #29
         };
 
@@ -132,13 +133,13 @@ namespace NetCoreTests
             // Then
             _projectFiles.Select(x => GetProjectPath(x)).ShouldBeSubsetOf(manager.Projects.Keys, log.ToString());
         }
-        
+
         [Test]
         public void IgnoreSolutionItemsThatAreNotProjects()
         {
             // Given / When
             AnalyzerManager manager = new AnalyzerManager(GetProjectPath("TestProjects.sln"));
-            
+
             // Then
             manager.Projects.Any(x => x.Value.ProjectFilePath.Contains("TestEmptySolutionFolder")).ShouldBeFalse();
         }

--- a/tests/projects/SdkProjectWithImportedProps/Class1.cs
+++ b/tests/projects/SdkProjectWithImportedProps/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SdkProjectWithImportedProps
+{
+    public class Class1
+    {
+        public void Foo()
+        {
+            Console.WriteLine("Bar");
+        }
+    }
+}

--- a/tests/projects/SdkProjectWithImportedProps/SdkProjectWithImportedProps.csproj
+++ b/tests/projects/SdkProjectWithImportedProps/SdkProjectWithImportedProps.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)\Test.props" />
+
+</Project>

--- a/tests/projects/SdkProjectWithImportedProps/Test.props
+++ b/tests/projects/SdkProjectWithImportedProps/Test.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+</Project>

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2027
@@ -20,6 +20,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkFrameworkProject", "SdkFrameworkProject\SdkFrameworkProject.csproj", "{7D74ABB0-2BF5-48EF-B1AE-A32B722276F6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProjectWithPackageReference", "LegacyFrameworkProjectWithPackageReference\LegacyFrameworkProjectWithPackageReference.csproj", "{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SdkProjectWithImportedProps", "SdkProjectWithImportedProps\SdkProjectWithImportedProps.csproj", "{A50B19F8-7FAA-4BE9-B292-666B60714F79}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,10 @@ Global
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD3445E2-A34A-4D87-9E8A-5081CBFA2F86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A50B19F8-7FAA-4BE9-B292-666B60714F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A50B19F8-7FAA-4BE9-B292-666B60714F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A50B19F8-7FAA-4BE9-B292-666B60714F79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A50B19F8-7FAA-4BE9-B292-666B60714F79}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This resolves usage of properties like MSBuildThisFileDirectory in project files.

I had actually taken the code from Roslyn MSBuild Workspaces project:
https://github.com/dotnet/roslyn/blob/master/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFileLoader.cs#L54
