### PR TITLE
Adds ability to set Global Properties at the AnalyzerManager level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Ignore repos cloned in unit tests
+tests/repos

--- a/Buildalyzer.sln
+++ b/Buildalyzer.sln
@@ -37,9 +37,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyFrameworkProjectWithP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkProjectWithImportedProps", "tests\projects\SdkProjectWithImportedProps\SdkProjectWithImportedProps.csproj", "{99080E4E-D2E6-4764-84E8-4EABCF449963}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrationTests", "tests\IntegrationTests\IntegrationTests.csproj", "{22FFD58A-723B-47D1-8716-7A464FE80DB4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "tests\IntegrationTests\IntegrationTests.csproj", "{22FFD58A-723B-47D1-8716-7A464FE80DB4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Buildalyzer.Tests", "tests\Buildalyzer.Tests\Buildalyzer.Tests.csproj", "{75A76A2E-6CBB-4BBF-9B7F-ACA308A8B5C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildalyzer.Tests", "tests\Buildalyzer.Tests\Buildalyzer.Tests.csproj", "{75A76A2E-6CBB-4BBF-9B7F-ACA308A8B5C7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8FD3A594-153D-4F6E-9D4F-12358C5C43B1}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+		ReleaseNotes.md = ReleaseNotes.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -91,7 +91,12 @@ These methods trigger compilation if it hasn't already been performed and will r
 
 Buildalyzer sets some MSBuild properties to make loading and compilation work the way it needs to (for example, to trigger a design-time build). You can view these properties with the `IReadOnlyDictionary<string, string>` property `ProjectAnalyzer.GlobalProperties`.
 
-If you want to change the configured properties before loading or compiling the project, use `ProjectAnalyzer.SetGlobalProperty(string key, string value)` and `ProjectAnalyzer.RemoveGlobalProperty(string key)`. Be careful though, you may break the ability to load, compile, or interpret the project if you change the MSBuild properties.
+If you want to change the configured properties before loading or compiling the project, there are two options:
+
+* `AnalyzerManager.SetGlobalProperty(string key, string value)` and `AnalyzerManager.RemoveGlobalProperty(string key)`. This will set the global properties for all projects loaded by this `AnalyzerManager`.
+* `ProjectAnalyzer.SetGlobalProperty(string key, string value)` and `ProjectAnalyzer.RemoveGlobalProperty(string key)`. This will set the global properties for just this project.
+
+Be careful though, you may break the ability to load, compile, or interpret the project if you change the MSBuild properties.
 
 ## Logging
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,9 @@
 
 - [Refactoring] Introduces a `ProjectTransformer` base class for specifying project file adjustments instead of a delegate
 - [Fix] Converts multi-targeted projects into a single target so Buildalyzer can build them (#29, #57)
+- [Fix] Calling `ProjectAnalyzer.SetGlobalProperty` and `ProjectAnalyzer.RemoveGlobalProperty` no longer leaks to projects sharing the same `BuildManager`
+- [Feature] Added ability to set global properties at the `AnalyzerManager` level (#52)
+- [Feature] Added ability to set environment variables for `AnalyzerManager` (all projects) and `ProjectAnalyzer` (specific project)
 
 # 0.5.0
 

--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -28,6 +28,10 @@ namespace Buildalyzer
         // Use a single BuildManager for each AnalyzerManager so the default per-process BuildManager doesn't conflict with other AnalyzerManagers
         internal BuildManager BuildManager { get; }
 
+        internal Dictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        internal Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         public string SolutionDirectory { get; }
 
         public AnalyzerManager(AnalyzerManagerOptions options = null)
@@ -130,6 +134,22 @@ namespace Buildalyzer
             }
 
             return GetProjectInternal(projectFilePath, projectDocument, false, buildEnvironment);
+        }
+
+        public void SetGlobalProperty(string key, string value)
+        {
+            GlobalProperties[key] = value;
+        }
+
+        public void RemoveGlobalProperty(string key)
+        {
+            // Nulls are removed before passing to MSBuild and can be used to ignore values in lower-precedence collections
+            GlobalProperties[key] = null;
+        }
+
+        public void SetEnvironmentVariable(string key, string value)
+        {
+            EnvironmentVariables[key] = value;
         }
 
         private ProjectAnalyzer GetProjectInternal(string projectFilePath, XDocument projectDocument, bool checkExists, BuildEnvironment buildEnvironment)

--- a/src/Buildalyzer/AnalyzerManagerOptions.cs
+++ b/src/Buildalyzer/AnalyzerManagerOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Xml.Linq;
+﻿using System.IO;
 using Buildalyzer.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
@@ -27,18 +25,6 @@ namespace Buildalyzer
                 LoggerFactory = new LoggerFactory();
                 LoggerFactory.AddProvider(new TextWriterLoggerProvider(value));
             }
-        }
-
-        private static ILoggerFactory CreateLoggerFactory(TextWriter logWriter)
-        {
-            if (logWriter != null)
-            {
-                LoggerFactory loggerFactory = new LoggerFactory();
-                loggerFactory.AddProvider(new TextWriterLoggerProvider(logWriter));
-                return loggerFactory;
-            }
-
-            return null;
         }
     }
 }

--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -18,10 +18,12 @@ namespace Buildalyzer.Environment
 
         internal Dictionary<string, string> GlobalProperties { get; }
 
+        internal Dictionary<string, string> EnvironmentVariables { get; }
+
         public BuildEnvironment(string msBuildExePath, string extensionsPath, string sdksPath, string roslynTargetsPath)
         {
             // Check if we've already specified a path to MSBuild
-            string envMsBuildExePath = System.Environment.GetEnvironmentVariable(EnvironmentVariables.MSBUILD_EXE_PATH);
+            string envMsBuildExePath = System.Environment.GetEnvironmentVariable(Environment.EnvironmentVariables.MSBUILD_EXE_PATH);
             MsBuildExePath = !string.IsNullOrEmpty(envMsBuildExePath) && File.Exists(envMsBuildExePath)
                 ? envMsBuildExePath : msBuildExePath;
 
@@ -31,7 +33,7 @@ namespace Buildalyzer.Environment
 
             // Set default global properties
             // MsBuildProperties.SolutionDir will get set by ProjectAnalyzer
-            GlobalProperties = new Dictionary<string, string>
+            GlobalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { MsBuildProperties.DesignTimeBuild, "true" },
                 { MsBuildProperties.BuildProjectReferences, "false" },
@@ -47,17 +49,16 @@ namespace Buildalyzer.Environment
                 { MsBuildProperties.MSBuildSDKsPath, SDKsPath },
                 { MsBuildProperties.RoslynTargetsPath, RoslynTargetsPath },
             };
-        }
 
-        internal IDisposable SetEnvironmentVariables() => new TemporaryEnvironment(
-            new Dictionary<string, string>
+            EnvironmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { MsBuildProperties.MSBuildExtensionsPath, ExtensionsPath },
                 { MsBuildProperties.MSBuildExtensionsPath32, ExtensionsPath },
                 { MsBuildProperties.MSBuildExtensionsPath64, ExtensionsPath },
                 { MsBuildProperties.MSBuildSDKsPath, SDKsPath },
-                { EnvironmentVariables.MSBUILD_EXE_PATH, MsBuildExePath }
-            });
+                { Environment.EnvironmentVariables.MSBUILD_EXE_PATH, MsBuildExePath }
+            };
+        }
 
         internal void Validate()
         {

--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -9,8 +9,6 @@ namespace Buildalyzer.Environment
 {
     internal static class DotnetPathResolver
     {
-        const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
-
         private static readonly object BasePathLock = new object();
         private static string BasePath = null;
 

--- a/src/Buildalyzer/ReleaseNotes.md
+++ b/src/Buildalyzer/ReleaseNotes.md
@@ -1,3 +1,0 @@
-# 0.1.0
-
-* Initial release


### PR DESCRIPTION
Adds ability to set Global Properties at the `AnalyzerManager` level. Also allows setting environment variables and fixes global property leak when sharing a `BuildEnvironment`.

Closes #52 