### PR TITLE
Upgrade depending packages [account for transitivities]

### DIFF
--- a/src/Buildalyzer/AssemblyResolver.cs
+++ b/src/Buildalyzer/AssemblyResolver.cs
@@ -61,7 +61,7 @@ namespace Buildalyzer
                 // Get all candidate paths, reflection-only load them (the get the version), and then take the one with the highest version
                 (string, Version)[] candidates = Directory.GetFiles(Path.GetDirectoryName(_buildEnvironment.MsBuildExePath), simpleName + ".dll", SearchOption.AllDirectories)
                     .Concat(Directory.GetFiles(Path.GetFullPath(Directory.GetParent(_buildEnvironment.SDKsPath).FullName), simpleName + ".dll", SearchOption.AllDirectories))
-                    .Concat(Directory.GetFiles(Path.GetFullPath(Directory.GetParent(_buildEnvironment.SDKsPath).FullName), simpleName + ".dll", SearchOption.AllDirectories)).Concat(Directory.GetFiles(_buildEnvironment.ExtensionsPath, simpleName + ".dll", SearchOption.AllDirectories))
+                    .Concat(Directory.GetFiles(_buildEnvironment.ExtensionsPath, simpleName + ".dll", SearchOption.AllDirectories))
                     .Distinct()
                     .Where(x => File.Exists(x))
                     .Select(x =>

--- a/src/Buildalyzer/AssemblyResolver.cs
+++ b/src/Buildalyzer/AssemblyResolver.cs
@@ -50,7 +50,7 @@ namespace Buildalyzer
 
             // Get all candidate paths
             string[] candidatePaths = Directory.GetFiles(Path.GetDirectoryName(_buildEnvironment.MsBuildExePath), simpleName + ".dll", SearchOption.AllDirectories)
-                .Concat(Directory.GetFiles(Path.GetFullPath(Path.Combine(_buildEnvironment.SDKsPath, @"..\")), simpleName + ".dll", SearchOption.AllDirectories))
+                .Concat(Directory.GetFiles(Path.GetFullPath(Directory.GetParent(_buildEnvironment.SDKsPath).ToString()), simpleName + ".dll", SearchOption.AllDirectories))
                 .Concat(Directory.GetFiles(_buildEnvironment.ExtensionsPath, simpleName + ".dll", SearchOption.AllDirectories))
                 .Distinct()
                 .Where(x => File.Exists(x))

--- a/src/Buildalyzer/AssemblyResolver.cs
+++ b/src/Buildalyzer/AssemblyResolver.cs
@@ -50,7 +50,7 @@ namespace Buildalyzer
 
             // Get all candidate paths
             string[] candidatePaths = Directory.GetFiles(Path.GetDirectoryName(_buildEnvironment.MsBuildExePath), simpleName + ".dll", SearchOption.AllDirectories)
-                .Concat(Directory.GetFiles(Path.GetFullPath(Directory.GetParent(_buildEnvironment.SDKsPath).ToString()), simpleName + ".dll", SearchOption.AllDirectories))
+                .Concat(Directory.GetFiles(Path.GetFullPath(Directory.GetParent(_buildEnvironment.SDKsPath).FullName), simpleName + ".dll", SearchOption.AllDirectories))
                 .Concat(Directory.GetFiles(_buildEnvironment.ExtensionsPath, simpleName + ".dll", SearchOption.AllDirectories))
                 .Distinct()
                 .Where(x => File.Exists(x))

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.7.179" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
   </ItemGroup>

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
There's a dependency transitivity issue (e.g., Roslyn and logging) that "forces" me to upgrade these packages. Note that my commits from the other cross-platform PR are also here (feel free to cherry-pick).