### PR TITLE
avoid exception when adding specific property in EnvironmentOption

### DIFF
--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -83,8 +83,14 @@ namespace Buildalyzer.Environment
             // (Re)set the enviornment variables that dotnet sets
             // See https://github.com/dotnet/cli/blob/0a4ad813ff971f549d34ac4ebc6c8cca9a741c36/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs#L22-L28
             // Especially important if a global.json is used because dotnet may set these to the latest, but then we'll call a msbuild.dll for the global.json version
-            additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
-            additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
+            if(additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
+            {
+                additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
+            }
+            if(additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
+            {
+                additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
+            }
 
             return new BuildEnvironment(
                 options.DesignTime,

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -83,11 +83,11 @@ namespace Buildalyzer.Environment
             // (Re)set the enviornment variables that dotnet sets
             // See https://github.com/dotnet/cli/blob/0a4ad813ff971f549d34ac4ebc6c8cca9a741c36/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs#L22-L28
             // Especially important if a global.json is used because dotnet may set these to the latest, but then we'll call a msbuild.dll for the global.json version
-            if(additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
+            if(!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
             {
                 additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
             }
-            if(additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
+            if(!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
             {
                 additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
             }


### PR DESCRIPTION
This PR fixes ArgumentException when following key exists in EnvironmentOption.EnvironmentVariables.

* MSBuildSDKsPath
* MSBuildExtensionsPath