### PR TITLE
add dotnet.exe setting variable for zip deployed SDK

### DIFF
--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -22,6 +22,7 @@ namespace Buildalyzer.Environment
         // Used for cloning
         private IDictionary<string, string> _additionalGlobalProperties;
         private IDictionary<string, string> _additionalEnvironmentVariables;
+        private string _dotnetExePath;
 
         public bool DesignTime { get; }
 
@@ -33,12 +34,15 @@ namespace Buildalyzer.Environment
 
         public IReadOnlyDictionary<string, string> EnvironmentVariables => _environmentVariables;
 
+        public string DotNetExePath => _dotnetExePath;
+
         public BuildEnvironment(
             bool designTime,
             string[] targetsToBuild,
             string msBuildExePath,
             IDictionary<string, string> additionalGlobalProperties = null,
-            IDictionary<string, string> additionalEnvironmentVariables = null)
+            IDictionary<string, string> additionalEnvironmentVariables = null,
+            string dotnetExePath = null)
         {
             DesignTime = designTime;
             TargetsToBuild = targetsToBuild ?? throw new ArgumentNullException(nameof(targetsToBuild));
@@ -81,6 +85,7 @@ namespace Buildalyzer.Environment
             // Set environment variables 
             _environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _additionalEnvironmentVariables = CopyItems(_environmentVariables, additionalEnvironmentVariables);
+            _dotnetExePath = dotnetExePath ?? "dotnet";
         }
 
         private Dictionary<string, string> CopyItems(Dictionary<string, string> destination, IDictionary<string, string> source)
@@ -113,6 +118,7 @@ namespace Buildalyzer.Environment
                 targets,
                 MsBuildExePath,
                 _additionalGlobalProperties,
-                _additionalEnvironmentVariables);
+                _additionalEnvironmentVariables,
+                _dotnetExePath);
     }
 }

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -21,7 +21,7 @@ namespace Buildalyzer.Environment
             _projectFile = projectFile;
             _logger = _manager.LoggerFactory?.CreateLogger<EnvironmentFactory>();
         }
-        
+
         public BuildEnvironment GetBuildEnvironment() =>
             GetBuildEnvironment(null, null);
 
@@ -30,7 +30,7 @@ namespace Buildalyzer.Environment
 
         public BuildEnvironment GetBuildEnvironment(EnvironmentOptions options) =>
             GetBuildEnvironment(null, options);
-        
+
         public BuildEnvironment GetBuildEnvironment(string targetFramework, EnvironmentOptions options)
         {
             options = options ?? new EnvironmentOptions();
@@ -53,19 +53,23 @@ namespace Buildalyzer.Environment
 
             return buildEnvironment ?? throw new InvalidOperationException("Could not find build environment");
         }
-        
+
         // Based on code from OmniSharp
         // https://github.com/OmniSharp/omnisharp-roslyn/blob/78ccc8b4376c73da282a600ac6fb10fce8620b52/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
         private BuildEnvironment CreateCoreEnvironment(EnvironmentOptions options)
         {
             // Get paths
             DotnetPathResolver pathResolver = new DotnetPathResolver(_manager.LoggerFactory);
-            string dotnetPath = pathResolver.ResolvePath(_projectFile.Path);
-            if(dotnetPath == null)
+            string dotnetPath = pathResolver.ResolvePath(_projectFile.Path, options.DotNetExePath);
+            if (dotnetPath == null)
             {
                 return null;
             }
             string msBuildExePath = Path.Combine(dotnetPath, "MSBuild.dll");
+            if(options.EnvironmentVariables.ContainsKey(Environment.EnvironmentVariables.MSBUILD_EXE_PATH))
+            {
+                msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
+            }
 
             // Clone the options global properties dictionary so we can add to it
             Dictionary<string, string> additionalGlobalProperties = new Dictionary<string, string>(options.GlobalProperties);
@@ -83,11 +87,11 @@ namespace Buildalyzer.Environment
             // (Re)set the enviornment variables that dotnet sets
             // See https://github.com/dotnet/cli/blob/0a4ad813ff971f549d34ac4ebc6c8cca9a741c36/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs#L22-L28
             // Especially important if a global.json is used because dotnet may set these to the latest, but then we'll call a msbuild.dll for the global.json version
-            if(!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
+            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildExtensionsPath))
             {
                 additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildExtensionsPath, dotnetPath);
             }
-            if(!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
+            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.MSBuildSDKsPath))
             {
                 additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
             }
@@ -97,7 +101,8 @@ namespace Buildalyzer.Environment
                 options.TargetsToBuild.ToArray(),
                 msBuildExePath,
                 additionalGlobalProperties,
-                additionalEnvironmentVariables);
+                additionalEnvironmentVariables,
+                options.DotNetExePath);
         }
 
         private BuildEnvironment CreateFrameworkEnvironment(EnvironmentOptions options)
@@ -112,21 +117,27 @@ namespace Buildalyzer.Environment
                 additionalGlobalProperties.Add(MsBuildProperties.NonExistentFile, Path.Combine("__NonExistentSubDir__", "__NonExistentFile__"));
             }
 
-            if (!GetFrameworkMsBuildExePath(out string msBuildExePath))
+            string msBuildExePath;
+            if(options != null && options.EnvironmentVariables.ContainsKey(EnvironmentVariables.MSBUILD_EXE_PATH))
+            {
+                msBuildExePath = options.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH];
+            }
+            else if (!GetFrameworkMsBuildExePath(out msBuildExePath))
             {
                 _logger?.LogWarning("Couldn't find a .NET Framework MSBuild path");
                 return null;
             }
-            
+
             // This is required to trigger NuGet package resolution and regeneration of project.assets.json
             additionalGlobalProperties.Add(MsBuildProperties.ResolveNuGetPackages, "true");
-            
+
             return new BuildEnvironment(
                 options.DesignTime,
                 options.TargetsToBuild.ToArray(),
                 msBuildExePath,
                 additionalGlobalProperties,
-                options.EnvironmentVariables);
+                options.EnvironmentVariables,
+                options.DotNetExePath);
         }
 
         private bool GetFrameworkMsBuildExePath(out string msBuildExePath)

--- a/src/Buildalyzer/Environment/EnvironmentOptions.cs
+++ b/src/Buildalyzer/Environment/EnvironmentOptions.cs
@@ -27,5 +27,6 @@ namespace Buildalyzer.Environment
         public IDictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>();
 
         public IDictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
+        public string DotNetExePath { get; set; } = "dotnet";
     }
 }

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -264,7 +264,7 @@ namespace Buildalyzer
             if (Path.GetExtension(buildEnvironment.MsBuildExePath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
             {
                 // .NET Core MSBuild .dll needs to be run with dotnet
-                fileName = "dotnet";
+                fileName = buildEnvironment.DotNetExePath;
                 initialArguments = $"\"{buildEnvironment.MsBuildExePath}\"";
             }
 


### PR DESCRIPTION
# Motivation

when I want to use daily SDK build, I use zip-deployed SDK(currently, dotnet-sdk-3.0.100-*).
Currently, I must prepend custom sdk's dotnet.exe directory path to  "PATH" env.
Because environment variable may have session-global effect, I want to avoid setting PATH env.

# Suggestion

adding "DotNetExePath" to EnvironmentOptions, and then use it in build.

