### PR TITLE
Improve Process Output/Error processing

### DIFF
--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -23,17 +23,6 @@ namespace Buildalyzer.Environment
         public string ResolvePath(string projectPath)
         {
             List<string> output = GetInfo(projectPath);
-            if (output.Count == 0)
-            {
-                // Need to rety calling "dotnet --info" and do a hacky timeout for the process otherwise it occasionally locks up during testing (and possibly in the field)
-                int retry = 0;
-                do
-                {
-                    Thread.Sleep(500);
-                    output = GetInfo(projectPath);
-                    retry++;
-                } while (output.Count == 0 && retry < 5);
-            }
 
             // Did we get any output?
             if (output == null || output.Count == 0)
@@ -66,13 +55,12 @@ namespace Buildalyzer.Environment
             };
 
             // global.json may change the version, so need to set working directory
-            List<string> output = new List<string>();
-            using (ProcessRunner processRunner = new ProcessRunner("dotnet", "--info", Path.GetDirectoryName(projectPath), environmentVariables, _loggerFactory, output))
+            using (ProcessRunner processRunner = new ProcessRunner("dotnet", "--info", Path.GetDirectoryName(projectPath), environmentVariables, _loggerFactory))
             {
                 processRunner.Start();
-                processRunner.Process.WaitForExit(4000);
+                processRunner.WaitForExit(4000);
+                return processRunner.Output;
             }
-            return output;
         }
 
         // Try to find a base path

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -244,8 +244,8 @@ namespace Buildalyzer
                             processRunner.Exited = () => cancellation.Cancel();
                             processRunner.Start();
                             pipeLogger.ReadAll();
-                            processRunner.Process.WaitForExit();
-                            exitCode = processRunner.Process.ExitCode;
+                            processRunner.WaitForExit();
+                            exitCode = processRunner.ExitCode;
                         }
 
                         // Collect the results


### PR DESCRIPTION
The way ProcessRunner was used, there was a race condition where the process could exit, WaitForExit would complete, and the process would be disposed of before all of the output was read.  There was a check in DotnetPathResolver for 0 lines, but I saw many cases where there was at least 1 line of output returned, but not all of them.

Switched from the event-based output/error processing to use ReadToEnd() on the Output and Error streams, encapsulated the Process more.  This code could be cleaned up further but I wanted to minimize change a bit.