### PR TITLE
Parallelize project builds during workspace creation

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Buildalyzer.Workspaces
 {
@@ -7,9 +9,14 @@ namespace Buildalyzer.Workspaces
         public static AdhocWorkspace GetWorkspace(this AnalyzerManager manager)
         {
             AdhocWorkspace workspace = new AdhocWorkspace();
-            foreach (ProjectAnalyzer project in manager.Projects.Values)
+
+            var builds = manager.Projects.Values
+                .AsParallel()
+                .Select(p => p.Build())
+                .ToList();
+            foreach (var build in builds)
             {
-                project.AddToWorkspace(workspace);
+                build.FirstOrDefault().AddToWorkspace(workspace);
             }
             return workspace;
         }


### PR DESCRIPTION
Parallelize the project builds when creating a workspace.  This massively reduces the time to generate the workspace for medium to large solutions.

I'm unsure about thread safety issues here and would welcome feedback but I did test this pretty extensively by loading a medium sized solution and generating a workspace 100 times in a loop.  I didn't see any errors and saw consistent structure in the generated workspace.

NOTE: I tested this on a branch that also had https://github.com/daveaglick/Buildalyzer/pull/90, otherwise I ran into warnings because the dotnet --info output wasn't being fully parsed.