### PR TITLE
Hack to prevent overwriting of Analyzer results for 2-pass web projects

### DIFF
--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -114,7 +114,8 @@ namespace Buildalyzer
 
         internal void ProcessCscCommandLine(string commandLine)
         {
-            if (string.IsNullOrWhiteSpace(commandLine))
+            //TODO: HACK - CSC gets called twice for Web projects with Razor pages, this ignores the 2nd pass
+            if (string.IsNullOrWhiteSpace(commandLine) || _cscCommandLineArguments != null)
             {
                 return;
             }


### PR DESCRIPTION
- CSC gets called twice for Web projects, 2nd pass to compile Razor pages.  This ignores the 2nd pass.

Hack/workaround for issue: https://github.com/daveaglick/Buildalyzer/issues/92