### PR TITLE
cherry-pick output processing fix

### DIFF
--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -222,8 +222,8 @@ namespace Buildalyzer
                             processRunner.Exited = () => cancellation.Cancel();
                             processRunner.Start();
                             pipeLogger.ReadAll();
-                            processRunner.Process.WaitForExit();
-                            exitCode = processRunner.Process.ExitCode;
+                            processRunner.WaitForExit();
+                            exitCode = processRunner.ExitCode;
                         }
 
                         // Collect the results


### PR DESCRIPTION
Clean pull request to replace https://github.com/daveaglick/Buildalyzer/pull/90.

This isn't the cleanest of code, the Output/Error processing being a side-effect of WaitForExit() seems a bit ugly, but WaitForExit() seems like a staple of anyone using the ProcessRunner class.

If you'd like me to restructure this, let me know