### PR TITLE
disable env var "COREHOST_TRACE" for .NET Core

### DIFF
--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -52,6 +52,7 @@ namespace Buildalyzer.Environment
             {
                 { EnvironmentVariables.DOTNET_CLI_UI_LANGUAGE, "en-US" },
                 { EnvironmentVariables.MSBUILD_EXE_PATH, null },
+                { EnvironmentVariables.COREHOST_TRACE, "0" },
                 { MsBuildProperties.MSBuildExtensionsPath, null }
             };
 

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -96,6 +96,10 @@ namespace Buildalyzer.Environment
             {
                 additionalEnvironmentVariables.Add(EnvironmentVariables.MSBuildSDKsPath, Path.Combine(dotnetPath, "Sdks"));
             }
+            if (!additionalEnvironmentVariables.ContainsKey(EnvironmentVariables.COREHOST_TRACE))
+            {
+                additionalEnvironmentVariables.Add(EnvironmentVariables.COREHOST_TRACE, "0");
+            }
 
             return new BuildEnvironment(
                 options.DesignTime,

--- a/src/Buildalyzer/Environment/EnvironmentVariables.cs
+++ b/src/Buildalyzer/Environment/EnvironmentVariables.cs
@@ -5,6 +5,7 @@
 #pragma warning disable SA1310 // Field names should not contain underscore
         public const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
         public const string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
+        public const string COREHOST_TRACE = nameof(COREHOST_TRACE);
 #pragma warning restore SA1310 // Field names should not contain underscore
         public const string MSBUILDDISABLENODEREUSE = nameof(MSBUILDDISABLENODEREUSE);
         public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);


### PR DESCRIPTION
When working on .NET Core, if environment variable "COREHOST_TRACE" is set to 1, huge amounts of debug text is printed within dotnet commands.

This debug text makes Buildalyzer freeze (wait longer than a minute to fetch .NET SDK path, in method DotnetPathResolver.GetInfo)

Disabling this environment variable on dotnet command processes makes Buildalyzer run on expected speeds again.
