### PR TITLE
Fix for finding the default SDK in some scenarios

### DIFF
--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -109,11 +109,26 @@ namespace Buildalyzer.Environment
             {
                 return null;
             }
+
             index++;
-            while (!string.IsNullOrWhiteSpace(lines[index + 1]))
+            while (true)
             {
+                if (index >= lines.Count - 1)
+                {
+                    throw new InvalidOperationException("Could not find the .NET SDK.");
+                }
+
+                // Not a version number or an empty string?
+                string temp = lines[index].Trim();
+                if (string.IsNullOrWhiteSpace(temp) || !char.IsDigit(temp[0]))
+                {
+                    index--;
+                    break;
+                }
+
                 index++;
             }
+
             string[] segments = lines[index]
                 .Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => !string.IsNullOrWhiteSpace(x))


### PR DESCRIPTION
When trying to find the default SDK and there isn't a global.json the default SDK finder sometimes throw a ArgumentOutOfRange exception because the line breaks between sections in the output from `dotnet --info` is missing for some reason.

This commit fixes one of those scenarios while keeping the original way of finding the SDK intact.