### PR TITLE
The SolutionDir property is different from the MSBuild output 

### DIFF
--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -59,8 +59,8 @@ namespace Buildalyzer
             ProjectFile = new ProjectFile(projectFilePath);
             EnvironmentFactory = new EnvironmentFactory(Manager, ProjectFile);
             ProjectInSolution = projectInSolution;
-            SolutionDirectory = string.IsNullOrEmpty(manager.SolutionFilePath)
-                ? Path.GetDirectoryName(projectFilePath) : Path.GetDirectoryName(manager.SolutionFilePath);
+            SolutionDirectory = (string.IsNullOrEmpty(manager.SolutionFilePath)
+                ? Path.GetDirectoryName(projectFilePath) : Path.GetDirectoryName(manager.SolutionFilePath)) + Path.DirectorySeparatorChar;
 
             // Get (or create) a project GUID
             ProjectGuid = projectInSolution == null

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -64,7 +64,7 @@ namespace Buildalyzer
 
             // Get (or create) a project GUID
             ProjectGuid = projectInSolution == null
-                ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFile.Path.Substring(SolutionDirectory.Length))
+                ? GuidUtility.Create(GuidUtility.UrlNamespace, ProjectFile.Path.Substring(SolutionDirectory.Length - 1))
                 : Guid.Parse(projectInSolution.ProjectGuid);
 
             // Set the solution directory global property

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -226,6 +226,16 @@ namespace Buildalyzer.Tests.Integration
         }
 
         [Test]
+        public void SolutionDirShouldEndWithDirectorySeparator()
+        {
+            // Given
+            StringWriter log = new StringWriter();
+            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj", log);
+
+            analyzer.SolutionDirectory.ShouldEndWith(Path.DirectorySeparatorChar.ToString());
+        }
+
+        [Test]
         public void MultiTargetingBuildFrameworkTargetFrameworkGetsSourceFiles()
         {
             // Given


### PR DESCRIPTION
The SolutionDir property does not end with a directory separator. This is different than how MSBuild sets this property:
