### PR TITLE
Bump `Microsoft.CodeAnalysis` packages to 3.7.0

### DIFF
--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In my project, I want to have:

```csproj
<PackageReference Include="Buildalyzer.Workspaces" Version="3.1.0" />
<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.0" />
```

which gives me following version conflict error:

```txt
myproject.csproj : error NU1107: Version conflict detected for Microsoft.CodeAnalysis.Common. Install/reference Microsoft.CodeAnalysis.Common 3.7.0 directly to project myproject to resolve this issue. 
myproject.csproj : error NU1107:  myproject -> Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 5.0.0 -> Microsoft.CodeAnalysis.Razor 5.0.0 -> Microsoft.CodeAnalysis.Common (>= 3.7.0)
myproject.csproj : error NU1107:  myproject -> Buildalyzer.Workspaces 3.1.0 -> Microsoft.CodeAnalysis.CSharp.Workspaces 3.6.0 -> Microsoft.CodeAnalysis.Common (= 3.6.0).
```

This PR fixes that issue.