### PR TITLE
Added support for analyzers and source generators

### DIFF
--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -82,6 +82,12 @@ namespace Buildalyzer
                 .Select(x => x.Item2)
                 .ToArray() ?? Array.Empty<string>();
 
+        public string[] AnalyzerReferences =>
+            _cscCommandLineArguments
+                ?.Where(x => x.Item1 == "analyzer")
+                .Select(x => x.Item2)
+                .ToArray() ?? Array.Empty<string>();
+
         public IEnumerable<string> ProjectReferences =>
             Items.TryGetValue("ProjectReference", out ProjectItem[] items)
                 ? items.Select(x => AnalyzerManager.NormalizePath(

--- a/src/Buildalyzer/IAnalyzerResult.cs
+++ b/src/Buildalyzer/IAnalyzerResult.cs
@@ -41,6 +41,8 @@ namespace Buildalyzer
 
         string[] References { get; }
 
+        string[] AnalyzerReferences { get; }
+
         string[] SourceFiles { get; }
 
         bool Succeeded { get; }

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -90,6 +90,21 @@ namespace Buildalyzer.Workspaces.Tests
             compilation.GetSymbolsWithName(x => x == "Class2").ShouldNotBeEmpty(log.ToString());
         }
 
+        [Test]
+        public void SupportsAnalyzers()
+        {
+            // Given
+            StringWriter log = new StringWriter();
+            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetCoreProjectWithAnalyzer\SdkNetCoreProjectWithAnalyzer.csproj", log);
+
+            // When
+            Workspace workspace = analyzer.GetWorkspace();
+            Project project = workspace.CurrentSolution.Projects.First();
+
+            // Then
+            project.AnalyzerReferences.ShouldContain(reference => reference.Display == "Microsoft.CodeQuality.Analyzers");
+        }
+
         private IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log, AnalyzerManager manager = null)
         {
             // The path will get normalized inside the .GetProject() call below

--- a/tests/projects/SdkNetCoreProjectWithAnalyzer/Class1.cs
+++ b/tests/projects/SdkNetCoreProjectWithAnalyzer/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SdkNetCoreProjectWithAnalyzer
+{
+    public class Class1
+    {
+        public void Foo()
+        {
+            Console.WriteLine("Bar");
+        }
+    }
+}

--- a/tests/projects/SdkNetCoreProjectWithAnalyzer/SdkNetCoreProjectWithAnalyzer.csproj
+++ b/tests/projects/SdkNetCoreProjectWithAnalyzer/SdkNetCoreProjectWithAnalyzer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/daveaglick/Buildalyzer/issues/157.

Note that source generators use the same mechanism of "analyzer" references, so this single change fixes both.