### PR TITLE
Add Referenced Projects

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -212,7 +212,7 @@ namespace Buildalyzer.Workspaces
 
         private static IEnumerable<IProjectAnalyzer> GetReferencedAnalyzerProjects(IAnalyzerResult analyzerResult) =>
             analyzerResult.ProjectReferences
-                .Select(x => analyzerResult.Manager.Projects.TryGetValue(x, out IProjectAnalyzer a) ? a : null)
+                .Select(x => analyzerResult.Manager.Projects.TryGetValue(x, out IProjectAnalyzer a) ? a : analyzerResult.Manager.GetProject(x))
                 .Where(x => x != null)
             ?? Array.Empty<ProjectAnalyzer>();
 

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -59,7 +59,7 @@ namespace Buildalyzer.Workspaces.Tests
         }
 
         [TestCase(false, 1)]
-        [TestCase(true, 2)]
+        [TestCase(true, 3)]
         public void AddsProjectReferences(bool addProjectReferences, int totalProjects)
         {
             // Given

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -65,7 +65,6 @@ namespace Buildalyzer.Workspaces.Tests
             // Given
             StringWriter log = new StringWriter();
             IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj", log);
-            GetProjectAnalyzer(@"projects\LegacyFrameworkProject\LegacyFrameworkProject.csproj", log, analyzer.Manager);
 
             // When
             Workspace workspace = analyzer.GetWorkspace(addProjectReferences);


### PR DESCRIPTION
Fixes #159 

This change adds to the functionality when you set `addProjectReferences` to `true`. At the moment it will follow all references where you have already added the project to the solution, but if you want to create an ad-hoc solution with a csproj as the entry point, I think you'll want this behaviour to automatically add references projects to the solution.

Just to be clear, the code change code (in `GetReferencedAnalyzerProjects`) is only called when `addProjectReferences` is `true`.