### PR TITLE
Add an interface for ProjectItem

### DIFF
--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -12,7 +12,7 @@ namespace Buildalyzer
     public class AnalyzerResult : IAnalyzerResult
     {
         private readonly Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, ProjectItem[]> _items = new Dictionary<string, ProjectItem[]>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, IProjectItem[]> _items = new Dictionary<string, IProjectItem[]>(StringComparer.OrdinalIgnoreCase);
         private readonly Guid _projectGuid;
         private List<(string, string)> _cscCommandLineArguments;
         private List<(string, string)> _fscCommandLineArguments;
@@ -44,7 +44,7 @@ namespace Buildalyzer
 
         public IReadOnlyDictionary<string, string> Properties => _properties;
 
-        public IReadOnlyDictionary<string, ProjectItem[]> Items => _items;
+        public IReadOnlyDictionary<string, IProjectItem[]> Items => _items;
 
         /// <inheritdoc/>
         public Guid ProjectGuid => _projectGuid;
@@ -89,14 +89,14 @@ namespace Buildalyzer
                 .ToArray() ?? Array.Empty<string>();
 
         public IEnumerable<string> ProjectReferences =>
-            Items.TryGetValue("ProjectReference", out ProjectItem[] items)
+            Items.TryGetValue("ProjectReference", out IProjectItem[] items)
                 ? items.Select(x => AnalyzerManager.NormalizePath(
                     Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.ItemSpec)))
                 : Array.Empty<string>();
 
         /// <inheritdoc/>
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences =>
-            Items.TryGetValue("PackageReference", out ProjectItem[] items)
+            Items.TryGetValue("PackageReference", out IProjectItem[] items)
                 ? items.Distinct(new ProjectItemItemSpecEqualityComparer()).ToDictionary(x => x.ItemSpec, x => x.Metadata)
                 : new Dictionary<string, IReadOnlyDictionary<string, string>>();
 
@@ -360,10 +360,10 @@ namespace Buildalyzer
             }
         }
 
-        private class ProjectItemItemSpecEqualityComparer : IEqualityComparer<ProjectItem>
+        private class ProjectItemItemSpecEqualityComparer : IEqualityComparer<IProjectItem>
         {
-            public bool Equals(ProjectItem x, ProjectItem y) => x.ItemSpec.Equals(y.ItemSpec);
-            public int GetHashCode(ProjectItem obj) => obj.ItemSpec.GetHashCode();
+            public bool Equals(IProjectItem x, IProjectItem y) => x.ItemSpec.Equals(y.ItemSpec);
+            public int GetHashCode(IProjectItem obj) => obj.ItemSpec.GetHashCode();
         }
     }
 }

--- a/src/Buildalyzer/IAnalyzerResult.cs
+++ b/src/Buildalyzer/IAnalyzerResult.cs
@@ -11,7 +11,7 @@ namespace Buildalyzer
         /// </summary>
         ProjectAnalyzer Analyzer { get; }
 
-        IReadOnlyDictionary<string, ProjectItem[]> Items { get; }
+        IReadOnlyDictionary<string, IProjectItem[]> Items { get; }
 
         AnalyzerManager Manager { get; }
 

--- a/src/Buildalyzer/IProjectItem.cs
+++ b/src/Buildalyzer/IProjectItem.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Buildalyzer
+{
+    public interface IProjectItem
+    {
+        string ItemSpec { get; }
+        IReadOnlyDictionary<string, string> Metadata { get; }
+    }
+}

--- a/src/Buildalyzer/ProjectItem.cs
+++ b/src/Buildalyzer/ProjectItem.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Logging;
 
 namespace Buildalyzer
 {
-    public class ProjectItem
+    public class ProjectItem : IProjectItem
     {
         public string ItemSpec { get; }
         public IReadOnlyDictionary<string, string> Metadata { get; }


### PR DESCRIPTION
Since the constructor of ProjectItem is internal it is very hard to mock the IAnalyzerResult properly.
Suggested improvement for: #161