### PR TITLE
When SolutionFilePath is available set in Workspace Solution

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -18,6 +18,13 @@ namespace Buildalyzer.Workspaces
 
             // Add each result to a new workspace
             AdhocWorkspace workspace = new AdhocWorkspace();
+
+            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+            {
+                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+                workspace.AddSolution(solutionInfo);
+            }
+
             foreach (AnalyzerResult result in results)
             {
                 result.AddToWorkspace(workspace);

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -29,6 +29,23 @@ namespace Buildalyzer.Workspaces.Tests
         }
 
         [Test]
+        public void LoadsSolution()
+        {
+            // Given
+            string solutionPath = GetFullPath(@"projects\TestProjects.sln");
+            StringWriter log = new StringWriter();
+            AnalyzerManager manager = new AnalyzerManager(solutionPath, new AnalyzerManagerOptions { LogWriter = log });
+
+            // When
+            Workspace workspace = manager.GetWorkspace();
+
+            // Then
+            workspace.CurrentSolution.FilePath.ShouldBe(solutionPath);
+            workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "LegacyFrameworkProject");
+            workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkFrameworkProject");
+        }
+
+        [Test]
         public void SupportsCompilation()
         {
             // Given
@@ -122,18 +139,21 @@ namespace Buildalyzer.Workspaces.Tests
         private IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log, AnalyzerManager manager = null)
         {
             // The path will get normalized inside the .GetProject() call below
-            string projectPath = Path.GetFullPath(
-                Path.Combine(
-                    Path.GetDirectoryName(typeof(ProjectAnalyzerExtensionsFixture).Assembly.Location),
-                    @"..\..\..\..\" + projectFile));
+            string projectPath = GetFullPath(projectFile);
             if (manager == null)
             {
-                manager = new AnalyzerManager(new AnalyzerManagerOptions
-                {
-                    LogWriter = log
-                });
+                manager = new AnalyzerManager(new AnalyzerManagerOptions { LogWriter = log });
             }
+
             return manager.GetProject(projectPath);
+        }
+
+        private static string GetFullPath(string partialPath)
+        {
+            return Path.GetFullPath(
+                Path.Combine(
+                    Path.GetDirectoryName(typeof(ProjectAnalyzerExtensionsFixture).Assembly.Location),
+                    @"..\..\..\..\" + partialPath));
         }
     }
 }


### PR DESCRIPTION
When creating a Workspace from an AnalyzerManager created from a solution file, this change ensures that `CurrentSolution.FilePath` is set correctly.

There were some failing integration tests but I think they're due to my environment being different.