### PR TITLE
Disable AppHost Creation

### DIFF
--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -98,6 +98,7 @@ namespace Buildalyzer.Environment
                 _globalProperties.Add(MsBuildProperties.AddModules, "false");
                 _globalProperties.Add(MsBuildProperties.UseCommonOutputDirectory, "true");  // This is used in a condition to prevent copying in _CopyFilesMarkedCopyLocal
                 _globalProperties.Add(MsBuildProperties.GeneratePackageOnBuild, "false");  // Prevent NuGet.Build.Tasks.Pack.targets from running the pack targets (since we didn't build anything)
+                _globalProperties.Add(MsBuildProperties.UseAppHost, "false"); // Prevent creation of native host executable https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#useapphost
             }
             _additionalGlobalProperties = CopyItems(_globalProperties, additionalGlobalProperties);
 

--- a/src/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/Buildalyzer/Environment/MsBuildProperties.cs
@@ -24,6 +24,7 @@
         public const string AddModules = nameof(AddModules);
         public const string UseCommonOutputDirectory = nameof(UseCommonOutputDirectory);
         public const string GeneratePackageOnBuild = nameof(GeneratePackageOnBuild);
+        public const string UseAppHost = nameof(UseAppHost);
 
         // .NET Framework code analysis rulesets
         public const string CodeAnalysisRuleDirectories = nameof(CodeAnalysisRuleDirectories);


### PR DESCRIPTION
In general this can be considered an optimization, but it also fixes an error that I'm running into where msbuild tries to copy the `apphost.exe`, but it doesn't exist.

I'd like to understand why it fails, but at the same time, a design-time build probably should be switching this off.