### PR TITLE
Handle self-contained apps

### DIFF
--- a/src/Buildalyzer/Construction/IProjectFile.cs
+++ b/src/Buildalyzer/Construction/IProjectFile.cs
@@ -6,6 +6,7 @@ namespace Buildalyzer.Construction
     {
         bool ContainsPackageReferences { get; }
         bool IsMultiTargeted { get; }
+        bool IsSelfContained { get; }
         IReadOnlyList<IPackageReference> PackageReferences { get; }
         string Path { get; }
         string Name { get; }

--- a/src/Buildalyzer/Construction/ProjectFile.cs
+++ b/src/Buildalyzer/Construction/ProjectFile.cs
@@ -101,6 +101,8 @@ namespace Buildalyzer.Construction
         /// </remarks>
         public bool IsMultiTargeted => _projectElement.GetDescendants(ProjectFileNames.TargetFrameworks).Any();
 
+        public bool IsSelfContained => _projectElement.GetDescendants(ProjectFileNames.SelfContained).Any();
+
         /// <summary>
         /// Whether the project file contains <c>PackageReference</c> items.
         /// </summary>

--- a/src/Buildalyzer/Construction/ProjectFileNames.cs
+++ b/src/Buildalyzer/Construction/ProjectFileNames.cs
@@ -11,6 +11,7 @@
         public const string Import = nameof(Import);
         public const string PackageReference = nameof(PackageReference);
         public const string ToolsVersion = nameof(ToolsVersion);
+        public const string SelfContained = nameof(SelfContained);
         public const string LanguageTargets = nameof(LanguageTargets);
 
         // Attributes

--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -101,7 +101,6 @@ namespace Buildalyzer.Environment
                 _globalProperties.Add(MsBuildProperties.AddModules, "false");
                 _globalProperties.Add(MsBuildProperties.UseCommonOutputDirectory, "true");  // This is used in a condition to prevent copying in _CopyFilesMarkedCopyLocal
                 _globalProperties.Add(MsBuildProperties.GeneratePackageOnBuild, "false");  // Prevent NuGet.Build.Tasks.Pack.targets from running the pack targets (since we didn't build anything)
-                _globalProperties.Add(MsBuildProperties.UseAppHost, "false"); // Prevent creation of native host executable https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#useapphost
             }
             _additionalGlobalProperties = CopyItems(_globalProperties, additionalGlobalProperties);
 

--- a/src/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -112,6 +112,7 @@ namespace Buildalyzer.Environment
             return new BuildEnvironment(
                 options.DesignTime,
                 options.Restore,
+                _projectFile.IsSelfContained,
                 options.TargetsToBuild.ToArray(),
                 msBuildExePath,
                 options.DotnetExePath,
@@ -149,6 +150,7 @@ namespace Buildalyzer.Environment
             return new BuildEnvironment(
                 options.DesignTime,
                 options.Restore,
+                _projectFile.IsSelfContained,
                 options.TargetsToBuild.ToArray(),
                 msBuildExePath,
                 options.DotnetExePath,

--- a/src/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/Buildalyzer/Environment/MsBuildProperties.cs
@@ -24,6 +24,7 @@
         public const string AddModules = nameof(AddModules);
         public const string UseCommonOutputDirectory = nameof(UseCommonOutputDirectory);
         public const string GeneratePackageOnBuild = nameof(GeneratePackageOnBuild);
+        public const string UseAppHost = nameof(UseAppHost);
 
         // .NET Framework code analysis rulesets
         public const string CodeAnalysisRuleDirectories = nameof(CodeAnalysisRuleDirectories);

--- a/src/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/Buildalyzer/Environment/MsBuildProperties.cs
@@ -24,7 +24,6 @@
         public const string AddModules = nameof(AddModules);
         public const string UseCommonOutputDirectory = nameof(UseCommonOutputDirectory);
         public const string GeneratePackageOnBuild = nameof(GeneratePackageOnBuild);
-        public const string UseAppHost = nameof(UseAppHost);
 
         // .NET Framework code analysis rulesets
         public const string CodeAnalysisRuleDirectories = nameof(CodeAnalysisRuleDirectories);

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -106,22 +106,14 @@ namespace Buildalyzer.Tests.Integration
             // Given
             StringWriter log = new StringWriter();
             IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
-            EnvironmentOptions options = new EnvironmentOptions
-            {
-                Preference = EnvironmentPreference.Core,
-
-                // DesignTime = false <- if this is default (= true), the test fails
-            };
 
             // When
             DeleteProjectDirectory(projectFile, "obj");
             DeleteProjectDirectory(projectFile, "bin");
-            IAnalyzerResults results = analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Build();
 
             // Then
-            results.Count.ShouldBeGreaterThan(0, log.ToString());
-            results.OverallSuccess.ShouldBeTrue(log.ToString());
-            results.ShouldAllBe(x => x.Succeeded, log.ToString());
+            results.Single().SourceFiles.Count().ShouldBeGreaterThan(0);
         }
 
         [Test]

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -99,6 +99,32 @@ namespace Buildalyzer.Tests.Integration
         }
 
         [Test]
+        public void HandlesSelfContainedApp()
+        {
+            string projectFile = @"SelfContainedApp\SelfContainedApp.csproj";
+
+            // Given
+            StringWriter log = new StringWriter();
+            IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+            EnvironmentOptions options = new EnvironmentOptions
+            {
+                Preference = EnvironmentPreference.Core,
+
+                // DesignTime = false <- if this is default (= true), the test fails
+            };
+
+            // When
+            DeleteProjectDirectory(projectFile, "obj");
+            DeleteProjectDirectory(projectFile, "bin");
+            IAnalyzerResults results = analyzer.Build(options);
+
+            // Then
+            results.Count.ShouldBeGreaterThan(0, log.ToString());
+            results.OverallSuccess.ShouldBeTrue(log.ToString());
+            results.ShouldAllBe(x => x.Succeeded, log.ToString());
+        }
+
+        [Test]
         public void GetsSourceFiles(
             [ValueSource(nameof(Preferences))] EnvironmentPreference preference,
             [ValueSource(nameof(ProjectFiles))] string projectFile)

--- a/tests/projects/SelfContainedApp/Program.cs
+++ b/tests/projects/SelfContainedApp/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/tests/projects/SelfContainedApp/SelfContainedApp.csproj
+++ b/tests/projects/SelfContainedApp/SelfContainedApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<SelfContained>true</SelfContained>
+	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNet5Project", "SdkNet5Pr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNet6Project", "SdkNet6Project\SdkNet6Project.csproj", "{54D4DF7E-CD98-4F46-961A-A006C5C1D03C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SelfContainedApp", "SelfContainedApp\SelfContainedApp.csproj", "{2605A734-42F5-4255-92E9-F438E0CDB8FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{54D4DF7E-CD98-4F46-961A-A006C5C1D03C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54D4DF7E-CD98-4F46-961A-A006C5C1D03C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54D4DF7E-CD98-4F46-961A-A006C5C1D03C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2605A734-42F5-4255-92E9-F438E0CDB8FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2605A734-42F5-4255-92E9-F438E0CDB8FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2605A734-42F5-4255-92E9-F438E0CDB8FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2605A734-42F5-4255-92E9-F438E0CDB8FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
As per the [docs](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#useapphost),
> A native executable is required for self-contained deployments.

Therefore this commit broke Buildalyzer for self-contained apps (the usecase is [here](https://github.com/stryker-mutator/stryker-net/issues/1855)). 

I'm not an MSBuild expert to handle this more elegantly so just reverting the original "optimization" :(