### PR TITLE
Added capability to use dotnet.exe only without MSBuild.dll

### DIFF
--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -70,7 +70,7 @@ namespace Buildalyzer.Environment
             string envMsBuildExePath = System.Environment.GetEnvironmentVariable(Environment.EnvironmentVariables.MSBUILD_EXE_PATH);
             MsBuildExePath = !string.IsNullOrEmpty(envMsBuildExePath) && File.Exists(envMsBuildExePath)
                 ? envMsBuildExePath : msBuildExePath;
-            if (MsBuildExePath == null)
+            if (string.IsNullOrWhiteSpace(MsBuildExePath) && string.IsNullOrWhiteSpace(dotnetExePath))
             {
                 throw new ArgumentNullException(nameof(msBuildExePath));
             }


### PR DESCRIPTION
If null or an empty string is provided for msBuildExePath parameter of BuildEnvironment constructor, but a path to dotnet.exe is provided in the dotnetExePath parameter, then this will now work by only calling dotnet.exe without any MSBuild involvement, so this library can then be used with dotnet.exe alone too. We need this functionality now that some of our solutions have been ported to net5/net6 and are built with dotnet.exe and functionalities which are only provided via dotnet.exe.