### PR TITLE
Use empty string as key for project properties if TargetFrameworkMonitor is not found

### DIFF
--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -103,8 +103,8 @@ namespace Buildalyzer.Logging
                     ?.ToDictionaryEntries()
                     .FirstOrDefault(x => string.Equals(x.Key.ToString(), "TargetFrameworkMoniker", StringComparison.OrdinalIgnoreCase))
                     .Value
-                    ?.ToString();
-                if (!string.IsNullOrWhiteSpace(tfm))
+                    ?.ToString() ?? string.Empty; // use an empty string if no target framework was found, for example in case of C++ projects with VS >= 2022
+                if (propertiesAndItems != null && propertiesAndItems.Properties != null && propertiesAndItems.Items != null)
                 {
                     if (!_results.TryGetValue(tfm, out AnalyzerResult result))
                     {


### PR DESCRIPTION
I have yet another Pull Request :D But I don't know if or how you want to implement this, or if you can think of a better solution.
The thing is, with Visual Studio 2022 the TargetFrameworkMoniker is no longer generated for C++ projects even though it is told so (which kinda makes sense since there's no TargetFramework for C++ projects).
This change would use an empty string as the key for project properties if the TargetFrameworkMoniker property wasn't found so the analysis can be run for non C#/Framework projects too, especially C++ projects with Visual Studio 2022.
This would mean a change of behaviour since it will now work with projects it hasn't worked with on previous Visual Studio installations too, like installer projects. We could simply accept that or we could introduce an additional optional parameter with EventProcessor class and Build method that would only allow for an empty TargetFrameworkMoniker if specifically told so.