### PR TITLE
Make AnalyzerResults deterministically ordered

### DIFF
--- a/src/Buildalyzer/AnalyzerResults.cs
+++ b/src/Buildalyzer/AnalyzerResults.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Buildalyzer
 {
@@ -23,9 +24,9 @@ namespace Buildalyzer
 
         public IAnalyzerResult this[string targetFramework] => _results[targetFramework];
 
-        public IEnumerable<string> TargetFrameworks => _results.Keys;
+        public IEnumerable<string> TargetFrameworks => _results.Keys.OrderBy(e => e, TargetFrameworkComparer.Instance);
 
-        public IEnumerable<IAnalyzerResult> Results => _results.Values;
+        public IEnumerable<IAnalyzerResult> Results => TargetFrameworks.Select(e => _results[e]);
 
         public int Count => _results.Count;
 
@@ -33,7 +34,7 @@ namespace Buildalyzer
 
         public bool TryGetTargetFramework(string targetFramework, out IAnalyzerResult result) => _results.TryGetValue(targetFramework, out result);
 
-        public IEnumerator<IAnalyzerResult> GetEnumerator() => _results.Values.GetEnumerator();
+        public IEnumerator<IAnalyzerResult> GetEnumerator() => Results.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>A little utility to perform design-time builds of .NET projects without having to think too hard about it. Should work with any project type on any .NET runtime.</Description>
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.3" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.0.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Microsoft.Build" Version="16.9.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" />

--- a/src/Buildalyzer/TargetFrameworkComparer.cs
+++ b/src/Buildalyzer/TargetFrameworkComparer.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace Buildalyzer
+{
+    internal class TargetFrameworkComparer : IComparer<string>
+    {
+        public static readonly TargetFrameworkComparer Instance = new TargetFrameworkComparer();
+
+        private static readonly NuGetFrameworkSorter Sorter = new NuGetFrameworkSorter();
+
+        private TargetFrameworkComparer()
+        {
+        }
+
+        public int Compare(string x, string y)
+        {
+            NuGetFramework xFramework = NuGetFramework.ParseFolder(x);
+            NuGetFramework yFramework = NuGetFramework.ParseFolder(y);
+            return Sorter.Compare(xFramework, yFramework);
+        }
+    }
+}

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -236,7 +236,7 @@ namespace Buildalyzer.Tests.Integration
             // Then
             // Multi-targeting projects product an extra result with an empty target framework that holds some MSBuild properties (I.e. the "outer" build)
             results.Count.ShouldBe(3);
-            results.TargetFrameworks.ShouldBe(new[] { "net462", "netstandard2.0", string.Empty }, true, log.ToString());
+            results.TargetFrameworks.ShouldBe(new[] { "net462", "netstandard2.0", string.Empty }, ignoreOrder: false, log.ToString());
             results[string.Empty].SourceFiles.ShouldBeEmpty();
             new[]
             {

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -125,10 +125,7 @@ namespace Buildalyzer.Tests.Integration
             sourceFiles.ShouldNotBeNull(log.ToString());
             new[]
             {
-#if Is_Windows
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
-#endif
                 analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
                 "AssemblyInfo"
             }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
@@ -188,10 +185,7 @@ namespace Buildalyzer.Tests.Integration
                 sourceFiles.ShouldNotBeNull(log.ToString());
                 new[]
                 {
-#if Is_Windows
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
-#endif
                 analyzer.ProjectFile.OutputType?.Equals("exe", StringComparison.OrdinalIgnoreCase) ?? false ? "Program" : "Class1",
                 "AssemblyInfo"
                 }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
@@ -205,8 +199,8 @@ namespace Buildalyzer.Tests.Integration
             }
         }
 
-#if Is_Windows
         [Test]
+        [Platform("win")]
         public void WpfControlLibraryGetsSourceFiles()
         {
             // Given
@@ -246,14 +240,12 @@ namespace Buildalyzer.Tests.Integration
             results[string.Empty].SourceFiles.ShouldBeEmpty();
             new[]
             {
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
                 "Class1",
                 "AssemblyInfo"
             }.ShouldBeSubsetOf(results["net462"].SourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
             new[]
             {
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
                 "Class2",
                 "AssemblyInfo"
@@ -285,13 +277,11 @@ namespace Buildalyzer.Tests.Integration
             sourceFiles.ShouldNotBeNull(log.ToString());
             new[]
             {
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
                 "Class1",
                 "AssemblyInfo"
             }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
         }
-#endif
 
         [Test]
         public void MultiTargetingBuildCoreTargetFrameworkGetsSourceFiles()
@@ -308,11 +298,8 @@ namespace Buildalyzer.Tests.Integration
             sourceFiles.ShouldNotBeNull(log.ToString());
             new[]
             {
-#if Is_Windows
-                // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
                 "AssemblyAttributes",
                 "AssemblyInfo",
-#endif
                 "Class2"
             }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());
         }
@@ -385,8 +372,8 @@ namespace Buildalyzer.Tests.Integration
 #endif
         }
 
-#if Is_Windows
         [Test]
+        [Platform("win")]
         public void LegacyFrameworkProjectWithPackageReferenceGetsReferences()
         {
             // Given
@@ -431,7 +418,6 @@ namespace Buildalyzer.Tests.Integration
             references.ShouldContain(x => x.EndsWith("LegacyFrameworkProject.csproj"), log.ToString());
             references.ShouldContain(x => x.EndsWith("LegacyFrameworkProjectWithPackageReference.csproj"), log.ToString());
         }
-#endif
 
         [Test]
         public void GetsProjectsInSolution()
@@ -501,7 +487,6 @@ namespace Buildalyzer.Tests.Integration
             results.First().ProjectGuid.ToString().ShouldBe("016713d9-b665-4272-9980-148801a9b88f");
         }
 
-#if Is_Windows
         [Test]
         public void GetsProjectGuidFromProject([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
         {
@@ -524,7 +509,6 @@ namespace Buildalyzer.Tests.Integration
             // so this may need to be updated periodically
             results.First().ProjectGuid.ToString().ShouldBe("1ff50b40-c27b-5cea-b265-29c5436a8a7b");
         }
-#endif
 
         [Test]
         public void BuildsProjectWithoutLogger([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
@@ -635,10 +619,7 @@ namespace Buildalyzer.Tests.Integration
             sourceFiles.ShouldNotBeNull(log.ToString());
             new[]
             {
-#if Is_Windows
-            // Linux and Mac builds appear to omit the AssemblyAttributes.cs file
             "AssemblyAttributes",
-#endif
             "Class1",
             "AssemblyInfo"
             }.ShouldBeSubsetOf(sourceFiles.Select(x => Path.GetFileName(x).Split('.').TakeLast(2).First()), log.ToString());


### PR DESCRIPTION
The order itself is not relevant (the `NuGetFrameworkSorter` used to sort target frameworks doesn't guarantee any specific order anyway) but the order is deterministic, meaning that several builds of the same project will always yield the same order of the target frameworks and results.

The nondeterministic nature of the current implementation made it hard to diagnose an implementation issue in Stryker.NET: https://github.com/stryker-mutator/stryker-net/issues/1899#issuecomment-1035432919