### PR TITLE
#210 A change so it can analyse Azure function apps. 

### DIFF
--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -184,7 +184,7 @@ namespace Buildalyzer
             ProcessedCommandLine cmd = ProcessCscCommandLine(commandLine);
 
             // Some projects can have multiple Csc calls (see #92) so if this is the one inside CoreCompile use it, otherwise use the first
-            if (coreCompile)
+            if (coreCompile || _cscCommandLineArguments == null)
             {
                 _command = cmd.Command;
                 _compilerFilePath = cmd.FileName;

--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -176,16 +176,24 @@ namespace Buildalyzer
 
         internal void ProcessCscCommandLine(string commandLine, bool coreCompile)
         {
-            // Some projects can have multiple Csc calls (see #92) so if this is the one inside CoreCompile use it, otherwise use the first
-            if (string.IsNullOrWhiteSpace(commandLine) || (_cscCommandLineArguments != null && !coreCompile))
+            if (string.IsNullOrWhiteSpace(commandLine))
             {
                 return;
             }
+
             ProcessedCommandLine cmd = ProcessCscCommandLine(commandLine);
-            _command = cmd.Command;
-            _compilerFilePath = cmd.FileName;
-            _compilerArguments = cmd.Arguments.ToArray();
-            _cscCommandLineArguments = cmd.ProcessedArguments;
+
+            // Some projects can have multiple Csc calls (see #92) so if this is the one inside CoreCompile use it, otherwise use the first
+            if (coreCompile)
+            {
+                _command = cmd.Command;
+                _compilerFilePath = cmd.FileName;
+                _compilerArguments = cmd.Arguments.ToArray();
+            }
+
+            // Azure function app projects have multiple Csc calls all of which are marked as coreCompile, so aggregate the ProcessedArguments.
+            _cscCommandLineArguments ??= new List<(string, string)>();
+            _cscCommandLineArguments.AddRange(cmd.ProcessedArguments);
         }
 
         internal static ProcessedCommandLine ProcessCscCommandLine(string commandLine)

--- a/tests/Buildalyzer.Tests/AnalyzerResultFixture.cs
+++ b/tests/Buildalyzer.Tests/AnalyzerResultFixture.cs
@@ -63,7 +63,7 @@ namespace Buildalyzer.Tests
             AnalyzerResult result = new AnalyzerResult(projectFilePath, null, null);
 
             // When
-            result.ProcessCscCommandLine(commandLine, true);
+            result.ProcessCscCommandLine(commandLine, false);
 
             // Then
             result.Command.ShouldBe(commandLine);

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -60,7 +60,7 @@ namespace Buildalyzer.Tests.Integration
             // In general, Buildalyzer is not good at analyzing any project that makes extensive use
             // of custom build tooling and tasks/targets because the behavior and log output is not consistent
             // See https://github.com/daveaglick/Buildalyzer/issues/210
-            // @"FunctionApp\FunctionApp.csproj",
+            @"FunctionApp\FunctionApp.csproj",
         };
 
         [Test]

--- a/tests/projects/FunctionApp/Class1.cs
+++ b/tests/projects/FunctionApp/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FunctionApp
+{
+    internal class Class1
+    {
+    }
+}

--- a/tests/projects/TestProjects.sln
+++ b/tests/projects/TestProjects.sln
@@ -52,9 +52,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkNet6SelfContained", "Sdk
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "VisualBasicNetConsoleApp", "VisualBasicProject\VisualBasicNetConsoleApp.vbproj", "{592A499F-F101-4ED6-82BE-052A5256B1A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorClassLibraryTest", "RazorClassLibraryTest\RazorClassLibraryTest.csproj", "{96E0901D-99F0-4D28-973E-98F288DF69B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RazorClassLibraryTest", "RazorClassLibraryTest\RazorClassLibraryTest.csproj", "{96E0901D-99F0-4D28-973E-98F288DF69B7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResponseFile", "ResponseFile\ResponseFile.csproj", "{B18DD8E6-9D47-4FDD-90EA-8F9C6789BE3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResponseFile", "ResponseFile\ResponseFile.csproj", "{B18DD8E6-9D47-4FDD-90EA-8F9C6789BE3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionApp", "FunctionApp\FunctionApp.csproj", "{BA707225-8976-4D6D-AB13-DA50A4562D22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -166,6 +168,10 @@ Global
 		{B18DD8E6-9D47-4FDD-90EA-8F9C6789BE3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B18DD8E6-9D47-4FDD-90EA-8F9C6789BE3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B18DD8E6-9D47-4FDD-90EA-8F9C6789BE3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA707225-8976-4D6D-AB13-DA50A4562D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA707225-8976-4D6D-AB13-DA50A4562D22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA707225-8976-4D6D-AB13-DA50A4562D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA707225-8976-4D6D-AB13-DA50A4562D22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
For Issue #210  
I don't fully understand how csc works, so this change is based on my observations of what is happening for the test project supplied in the defect, i.e. that the changed method is called twice both with coreCompile set to true, the first one contains the file paths for the source files. So the solution that appears to work is to aggregate the the results of the two calls together, attempted in a way to not interfere with other kinds of project, or what the app was doing before.

I have no idea which of the two commands should be retained as the command, so the last one wins.
I have run the tests and run the example project supplied on the defect with this fix and it produces an output which includes all the source files.  
On my box I still get that running a design time build of the function app throws an error, which occurs for me on the integration test that does a design time build of the test Function app, however as you don't seem to have that problem it will be interesting to see if the tests pass for you

