### PR TITLE
Fixed a NullReferenceException for F# projects

### DIFF
--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -90,7 +90,7 @@ namespace Buildalyzer
                     && !string.Equals(Path.GetFileName(x.Item2), "csc.exe", StringComparison.OrdinalIgnoreCase))
                 .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
                 .ToArray() ?? _fscCommandLineArguments
-                ?.Where(x => x.Item1 == null
+                ?.Where(x => x.Item1 == null && x.Item2 != null
                     && !x.Item2.Contains("fsc.dll")
                     && !x.Item2.Contains("fsc.exe"))
                 .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))

--- a/src/Buildalyzer/AnalyzerResult.cs
+++ b/src/Buildalyzer/AnalyzerResult.cs
@@ -90,9 +90,9 @@ namespace Buildalyzer
                     && !string.Equals(Path.GetFileName(x.Item2), "csc.exe", StringComparison.OrdinalIgnoreCase))
                 .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
                 .ToArray() ?? _fscCommandLineArguments
-                ?.Where(x => x.Item1 == null && x.Item2 != null
-                    && !x.Item2.Contains("fsc.dll")
-                    && !x.Item2.Contains("fsc.exe"))
+                ?.Where(x => x.Item1 == null
+                    && x.Item2?.Contains("fsc.dll") == false
+                    && x.Item2?.Contains("fsc.exe") == false)
                 .Select(x => AnalyzerManager.NormalizePath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.Item2)))
                 .ToArray() ?? _vbcCommandLineArguments
                 ?.Where(x => x.Item1 == null && !_assemblyObjects.Contains(Path.GetFileName(x.Item2), StringComparer.OrdinalIgnoreCase))

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -557,6 +557,7 @@ namespace Buildalyzer.Tests.Integration
 
             // Then
             results.Count.ShouldBeGreaterThan(0, log.ToString());
+            results.First().SourceFiles.ShouldNotBeNull();
             results.OverallSuccess.ShouldBeTrue(log.ToString());
             results.ShouldAllBe(x => x.Succeeded, log.ToString());
         }


### PR DESCRIPTION
That big LINQ query started to throw for F# since the first cmd-line argument is a tuple `(null, null)`.
In tests, it's enough to just call `SourceFiles`.