### PR TITLE
Convert relative paths to absolute paths for analyzer references

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -288,9 +288,8 @@ namespace Buildalyzer.Workspaces
         {
             IAnalyzerAssemblyLoader loader = workspace.Services.GetRequiredService<IAnalyzerService>().GetLoader();
 
-            return analyzerResult
-                .AnalyzerReferences?.Where(File.Exists)
-                .Select(x => new AnalyzerFileReference(x, loader))
+            return analyzerResult.AnalyzerReferences?.Where(x => File.Exists(Path.GetFullPath(x)))
+                .Select(x => new AnalyzerFileReference(Path.GetFullPath(x), loader))
                 ?? (IEnumerable<AnalyzerReference>)Array.Empty<AnalyzerReference>();
         }
 


### PR DESCRIPTION
This PR fixes an issue where the `AnalyzerResultExtensions.GetAnalyzerReferences` method allows the return of relative paths instead of absolute paths as expected by Roslyn and causing an exception to be thrown.

Depending on the execution environment: from within Visual Studio, from the command line by running the executable, or via `dotnet run` some references may be passed in as relative paths. If these references are then passed to the Roslyn subsystem then you will see an exception similar to below (call stack has been abbreviated and code related to PR is highlighted):

```
Unhandled exception. System.ArgumentException: Absolute path expected. (Parameter 'fullPath')

***
at Roslyn.Utilities.CompilerPathUtilities.RequireAbsolutePath(String path, String argumentName)
at Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference..ctor(String fullPath, IAnalyzerAssemblyLoader assemblyLoader)
at Buildalyzer.Workspaces.AnalyzerResultExtensions.<>c__DisplayClass9_0.<GetAnalyzerReferences>b__0(String x)
***

at System.Linq.Enumerable.WhereSelectArrayIterator`2.MoveNext()
at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
at System.Collections.Immutable.ImmutableArray.CreateRange[T](IEnumerable`1 items)
at Roslyn.Utilities.EnumerableExtensions.ToBoxedImmutableArray[T](IEnumerable`1 items)
at Microsoft.CodeAnalysis.ProjectInfo.Create(ProjectId id, VersionStamp version, String name, String assemblyName, String language, String filePath, String outputFilePath, CompilationOptions compilationOptions, ParseOptions parseOptions, IEnumerable`1 documents, IEnumerable`1 projectReferences, IEnumerable`1 metadataReferences, IEnumerable`1 analyzerReferences, IEnumerable`1 additionalDocuments, Boolean isSubmission, Type hostObjectType, String outputRefFilePath)
at Buildalyzer.Workspaces.AnalyzerResultExtensions.GetProjectInfo(IAnalyzerResult analyzerResult, Workspace workspace, ProjectId projectId)
at Buildalyzer.Workspaces.AnalyzerResultExtensions.AddToWorkspace(IAnalyzerResult analyzerResult, Workspace workspace, Boolean addProjectReferences)
at Buildalyzer.Workspaces.ProjectAnalyzerExtensions.AddToWorkspace(IProjectAnalyzer analyzer, Workspace workspace, Boolean addProjectReferences)
at Buildalyzer.Workspaces.ProjectAnalyzerExtensions.GetWorkspace(IProjectAnalyzer analyzer, Boolean addProjectReferences)
...
```

This PR fixes that issue by using the `Path.GetFullPath` .NET method to convert all paths in the extension method to absolute paths before returning them from the method.