### PR TITLE
Support nullable context options

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -237,7 +237,9 @@ namespace Buildalyzer.Workspaces
                 // language-specific code is in local functions, to prevent assembly loading failures when assembly for the other language is not available
                 if (languageName == LanguageNames.CSharp)
                 {
-                    CompilationOptions CreateCSharpCompilationOptions() => new CSharpCompilationOptions(kind.Value);
+                    Enum.TryParse(analyzerResult.GetProperty("Nullable"), ignoreCase: true, out NullableContextOptions nullable);
+
+                    CompilationOptions CreateCSharpCompilationOptions() => new CSharpCompilationOptions(kind.Value, nullableContextOptions: nullable);
 
                     return CreateCSharpCompilationOptions();
                 }

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -1,220 +1,232 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
 
-namespace Buildalyzer.Workspaces.Tests
+namespace Buildalyzer.Workspaces.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class ProjectAnalyzerExtensionsFixture
 {
-    [TestFixture]
-    [NonParallelizable]
-    public class ProjectAnalyzerExtensionsFixture
+    [Test]
+    public void LoadsWorkspace()
     {
-        [Test]
-        public void LoadsWorkspace()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            workspace.CurrentSolution.Projects.First().Documents.ShouldContain(x => x.Name == "Class1.cs", log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        workspace.CurrentSolution.Projects.First().Documents.ShouldContain(x => x.Name == "Class1.cs", log.ToString());
+    }
 
-        [Test]
-        public void LoadsSolution()
-        {
-            // Given
-            string solutionPath = GetFullPath(@"projects\TestProjects.sln");
-            SafeStringWriter log = new SafeStringWriter();
-            AnalyzerManager manager = new AnalyzerManager(solutionPath, new AnalyzerManagerOptions { LogWriter = log });
+    [Test]
+    public void LoadsSolution()
+    {
+        // Given
+        string solutionPath = GetFullPath(@"projects\TestProjects.sln");
+        SafeStringWriter log = new SafeStringWriter();
+        AnalyzerManager manager = new AnalyzerManager(solutionPath, new AnalyzerManagerOptions { LogWriter = log });
 
-            // When
-            Workspace workspace = manager.GetWorkspace();
+        // When
+        Workspace workspace = manager.GetWorkspace();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            workspace.CurrentSolution.FilePath.ShouldBe(solutionPath);
-            workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "LegacyFrameworkProject");
-            workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkFrameworkProject");
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        workspace.CurrentSolution.FilePath.ShouldBe(solutionPath);
+        workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "LegacyFrameworkProject");
+        workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkFrameworkProject");
+    }
 
-        [Test]
-        public async Task SupportsCompilation()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
+    [Test]
+    public async Task SupportsCompilation()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
-            Compilation compilation = await workspace.CurrentSolution.Projects.First().GetCompilationAsync();
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        Compilation compilation = await workspace.CurrentSolution.Projects.First().GetCompilationAsync();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            compilation.GetSymbolsWithName(x => x == "Class1").ShouldNotBeEmpty(log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        compilation.GetSymbolsWithName(x => x == "Class1").ShouldNotBeEmpty(log.ToString());
+    }
 
-        [Test]
-        public void CreatesCompilationOptions()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
+    [Test]
+    public void CreatesCompilationOptions()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProject\SdkNetStandardProject.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
-            CompilationOptions compilationOptions = workspace.CurrentSolution.Projects.First().CompilationOptions;
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        CompilationOptions compilationOptions = workspace.CurrentSolution.Projects.First().CompilationOptions;
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            compilationOptions.OutputKind.ShouldBe(OutputKind.DynamicallyLinkedLibrary, log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        compilationOptions.OutputKind.ShouldBe(OutputKind.DynamicallyLinkedLibrary, log.ToString());
+    }
 
-        [TestCase(false, 1)]
-        [TestCase(true, 3)]
-        public void AddsProjectReferences(bool addProjectReferences, int totalProjects)
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj", log);
+    [TestCase(false, 1)]
+    [TestCase(true, 3)]
+    public void AddsProjectReferences(bool addProjectReferences, int totalProjects)
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\LegacyFrameworkProjectWithReference\LegacyFrameworkProjectWithReference.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace(addProjectReferences);
+        // When
+        Workspace workspace = analyzer.GetWorkspace(addProjectReferences);
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
+    }
 
-        [TestCase(false, 1)]
-        [TestCase(true, 4)]
-        public void AddsTransitiveProjectReferences(bool addProjectReferences, int totalProjects)
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\TransitiveProjectReference\TransitiveProjectReference.csproj", log);
+    [TestCase(false, 1)]
+    [TestCase(true, 4)]
+    public void AddsTransitiveProjectReferences(bool addProjectReferences, int totalProjects)
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\TransitiveProjectReference\TransitiveProjectReference.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace(addProjectReferences);
+        // When
+        Workspace workspace = analyzer.GetWorkspace(addProjectReferences);
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        workspace.CurrentSolution.Projects.Count().ShouldBe(totalProjects, log.ToString());
+    }
 
-        [Test]
-        public async Task SupportsConstants()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj", log);
+    [Test]
+    public async Task SupportsConstants()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetStandardProjectWithConstants\SdkNetStandardProjectWithConstants.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
-            Compilation compilation = await workspace.CurrentSolution.Projects.First().GetCompilationAsync();
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        Compilation compilation = await workspace.CurrentSolution.Projects.First().GetCompilationAsync();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            compilation.GetSymbolsWithName(x => x == "Class1").ShouldBeEmpty(log.ToString());
-            compilation.GetSymbolsWithName(x => x == "Class2").ShouldNotBeEmpty(log.ToString());
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        compilation.GetSymbolsWithName(x => x == "Class1").ShouldBeEmpty(log.ToString());
+        compilation.GetSymbolsWithName(x => x == "Class2").ShouldNotBeEmpty(log.ToString());
+    }
 
-        [Test]
-        public void SupportsAnalyzers()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetCore2ProjectWithAnalyzer\SdkNetCore2ProjectWithAnalyzer.csproj", log);
+    [Test]
+    public void SupportsAnalyzers()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkNetCore2ProjectWithAnalyzer\SdkNetCore2ProjectWithAnalyzer.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
-            Project project = workspace.CurrentSolution.Projects.First();
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        Project project = workspace.CurrentSolution.Projects.First();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            project.AnalyzerReferences.ShouldContain(reference => reference.Display == "Microsoft.CodeQuality.Analyzers");
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        project.AnalyzerReferences.ShouldContain(reference => reference.Display == "Microsoft.CodeQuality.Analyzers");
+    }
 
-        [Test]
-        public void SupportsAdditionalFiles()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
+    [Test]
+    public void SupportsAdditionalFiles()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\ProjectWithAdditionalFile\ProjectWithAdditionalFile.csproj", log);
 
-            // When
-            Workspace workspace = analyzer.GetWorkspace();
-            Project project = workspace.CurrentSolution.Projects.First();
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        Project project = workspace.CurrentSolution.Projects.First();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            project.AdditionalDocuments.Select(d => d.Name).ShouldBe(new[] { "message.txt" });
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        project.AdditionalDocuments.Select(d => d.Name).ShouldBe(new[] { "message.txt" });
+    }
+
+    [Test]
+    public async Task SupportsNullabilityEnabled()
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\NullabilityEnabled\NullabilityEnabled.csproj", log);
+        AdhocWorkspace workspace = analyzer.GetWorkspace();
+        Project project = workspace.CurrentSolution.Projects.Single();
+
+        // When
+        Compilation compilation = await project.GetCompilationAsync();
+
+        Diagnostic[] diagnostics = compilation.GetDiagnostics().Where(d => d.Id == "CS8632").ToArray();
+
+        diagnostics.ShouldBeEmpty();
+    }
 
 #if Is_Windows
-        [Test]
-        public void HandlesWpfCustomControlLibrary()
-        {
-            // Given
-            SafeStringWriter log = new SafeStringWriter();
-            IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\WpfCustomControlLibrary1\WpfCustomControlLibrary1.csproj", log);
+    [Test]
+    public void HandlesWpfCustomControlLibrary()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\WpfCustomControlLibrary1\WpfCustomControlLibrary1.csproj", log);
 
-            // When
-            AdhocWorkspace workspace = analyzer.GetWorkspace();
-            Project project = workspace.CurrentSolution.Projects.First();
+        // When
+        AdhocWorkspace workspace = analyzer.GetWorkspace();
+        Project project = workspace.CurrentSolution.Projects.First();
 
-            // Then
-            string logged = log.ToString();
-            logged.ShouldNotContain("Workspace failed", logged);
-            project.ShouldNotBeNull();
-            project.Documents.ShouldNotBeEmpty();
-        }
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed", logged);
+        project.ShouldNotBeNull();
+        project.Documents.ShouldNotBeEmpty();
+    }
 #endif
 
-        private IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log, AnalyzerManager manager = null)
+    private IProjectAnalyzer GetProjectAnalyzer(string projectFile, StringWriter log, AnalyzerManager manager = null)
+    {
+        // The path will get normalized inside the .GetProject() call below
+        string projectPath = GetFullPath(projectFile);
+        if (manager == null)
         {
-            // The path will get normalized inside the .GetProject() call below
-            string projectPath = GetFullPath(projectFile);
-            if (manager == null)
-            {
-                manager = new AnalyzerManager(new AnalyzerManagerOptions { LogWriter = log });
-            }
-
-            return manager.GetProject(projectPath);
+            manager = new AnalyzerManager(new AnalyzerManagerOptions { LogWriter = log });
         }
 
-        private static string GetFullPath(string partialPath)
-        {
-            return Path
-                .GetFullPath(
-                    Path.Combine(
-                        Path.GetDirectoryName(
-                            typeof(ProjectAnalyzerExtensionsFixture).Assembly.Location),
+        return manager.GetProject(projectPath);
+    }
+
+    private static string GetFullPath(string partialPath)
+    {
+        return Path
+            .GetFullPath(
+                Path.Combine(
+                    Path.GetDirectoryName(
+                        typeof(ProjectAnalyzerExtensionsFixture).Assembly.Location),
 #if Is_Windows
-                        @"..\..\..\..\" + partialPath));
+                    @"..\..\..\..\" + partialPath));
 #else
-                        "../../../../" + partialPath))
-                .Replace(@"\", "/");
+                    "../../../../" + partialPath))
+            .Replace(@"\", "/");
 #endif
-        }
     }
 }

--- a/tests/projects/NullabilityEnabled/NullabilityEnabled.csproj
+++ b/tests/projects/NullabilityEnabled/NullabilityEnabled.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+	<Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/projects/NullabilityEnabled/SimpleModel.cs
+++ b/tests/projects/NullabilityEnabled/SimpleModel.cs
@@ -1,0 +1,6 @@
+﻿namespace NullabilityEnabled;
+
+public class SimpleModel
+{
+	public string? Value { get; init; }
+}


### PR DESCRIPTION
I noticed that the [`NullableContextOptions`](https://sourceroslyn.io/#Microsoft.CodeAnalysis/Compilation/NullableContextOptions.cs) where not set while creating the `CSharpCompilationOptions`. With this PR, that should be fixed.