### PR TITLE
Adding timeout to the dotnet info command, using environment variables.

### DIFF
--- a/src/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -59,8 +59,12 @@ namespace Buildalyzer.Environment
             // global.json may change the version, so need to set working directory
             using (ProcessRunner processRunner = new ProcessRunner(dotnetExePath, "--info", Path.GetDirectoryName(projectPath), environmentVariables, _loggerFactory))
             {
+                int dotnetInfoWaitTime = int.TryParse(System.Environment.GetEnvironmentVariable(EnvironmentVariables.DOTNET_INFO_WAIT_TIME), out int dotnetInfoWaitTimeParsed)
+                    ? dotnetInfoWaitTimeParsed
+                    : 4000;
+                _logger?.LogInformation($"dotnet --info wait time is {dotnetInfoWaitTime}ms");
                 processRunner.Start();
-                processRunner.WaitForExit(4000);
+                processRunner.WaitForExit(dotnetInfoWaitTime);
                 return processRunner.Output;
             }
         }

--- a/src/Buildalyzer/Environment/EnvironmentVariables.cs
+++ b/src/Buildalyzer/Environment/EnvironmentVariables.cs
@@ -8,6 +8,7 @@
         public const string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
         public const string COREHOST_TRACE = nameof(COREHOST_TRACE);
         public const string DOTNET_HOST_PATH = nameof(DOTNET_HOST_PATH);
+        public const string DOTNET_INFO_WAIT_TIME = nameof(DOTNET_INFO_WAIT_TIME);
 #pragma warning restore CA1707
 #pragma warning restore SA1310 // Field names should not contain underscore
         public const string MSBUILDDISABLENODEREUSE = nameof(MSBUILDDISABLENODEREUSE);


### PR DESCRIPTION
**Description**
In some scenarios 4000ms to execute the dotnet --info command is not enough.

**Objective** 
The objective is to add the possibility of passing the desired timeout via environment variable.

**Scenario**
I identified this scenario when running the solution within k8s clusters with low memory and CPU.

[Related Issue](https://github.com/daveaglick/Buildalyzer/issues/228)