### PR TITLE
Restore sorting empty target framework last

### DIFF
--- a/src/Buildalyzer/AnalyzerResults.cs
+++ b/src/Buildalyzer/AnalyzerResults.cs
@@ -25,7 +25,7 @@ namespace Buildalyzer
 
         public IAnalyzerResult this[string targetFramework] => _results[targetFramework];
 
-        public IEnumerable<string> TargetFrameworks => _results.Keys.OrderBy(e => e, StringComparer.OrdinalIgnoreCase);
+        public IEnumerable<string> TargetFrameworks => _results.Keys.OrderBy(e => e, TargetFrameworkComparer.Instance);
 
         public IEnumerable<IAnalyzerResult> Results => TargetFrameworks.Select(e => _results[e]);
 
@@ -38,5 +38,21 @@ namespace Buildalyzer
         public IEnumerator<IAnalyzerResult> GetEnumerator() => Results.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private class TargetFrameworkComparer : IComparer<string>
+        {
+            public static TargetFrameworkComparer Instance { get; } = new TargetFrameworkComparer();
+
+            public int Compare(string x, string y)
+            {
+                return (string.IsNullOrEmpty(x), string.IsNullOrEmpty(y)) switch
+                {
+                    (true, true) => 0,
+                    (true, false) => +1,
+                    (false, true) => -1,
+                    _ => StringComparer.OrdinalIgnoreCase.Compare(x, y)
+                };
+            }
+        }
     }
 }

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -244,7 +244,7 @@ namespace Buildalyzer.Tests.Integration
             // Then
             // Multi-targeting projects product an extra result with an empty target framework that holds some MSBuild properties (I.e. the "outer" build)
             results.Count.ShouldBe(3);
-            results.TargetFrameworks.ShouldBe(new[] { string.Empty, "net462", "netstandard2.0" }, ignoreOrder: false, log.ToString());
+            results.TargetFrameworks.ShouldBe(new[] { "net462", "netstandard2.0", string.Empty }, ignoreOrder: false, log.ToString());
             results[string.Empty].SourceFiles.ShouldBeEmpty();
             new[]
             {


### PR DESCRIPTION
Commit 8e85a15e324a65f9da5033f3d8a2320c76dda378 dropped the NuGet.Frameworks dependency and as a result sorting of the target frameworks behaviour changed.

Previously, the `NuGetFrameworkSorter` would sort the empty target framework last. Since 8e85a15e324a65f9da5033f3d8a2320c76dda378 the empty target framework is sorted first.

This commit restores the old behaviour of sorting the empty target framework last.

Note: Stryker.NET was inadvertently depending on this behaviour, so v6.0.1 broke Stryker.NET. I have [fixed the issue in Styker.NET](https://github.com/stryker-mutator/stryker-net/pull/2811) but I think restoring the previous sorting behaviour is a good idea anyway.