### PR TITLE
Introduction of solution info and project file info

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
-
 namespace Buildalyzer.Workspaces;
 
 public static class AnalyzerManagerExtensions
@@ -39,7 +38,7 @@ public static class AnalyzerManagerExtensions
         AdhocWorkspace workspace = manager.CreateWorkspace();
         if (!string.IsNullOrEmpty(manager.SolutionFilePath))
         {
-            SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+            Microsoft.CodeAnalysis.SolutionInfo solutionInfo = Microsoft.CodeAnalysis.SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
             workspace.AddSolution(solutionInfo);
 
             // Sort the projects so the order that they're added to the workspace in the same order as the solution file

--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -62,7 +62,7 @@ public static class AnalyzerResultExtensions
         analyzerResult.Manager.WorkspaceProjectReferences[projectId.Id] = [.. analyzerResult.ProjectReferences];
 
         // Create and add the project, but only if it's a support Roslyn project type
-        ProjectInfo projectInfo = GetProjectInfo(analyzerResult, workspace, projectId);
+        Microsoft.CodeAnalysis.ProjectInfo projectInfo = GetProjectInfo(analyzerResult, workspace, projectId);
         if (projectInfo is null)
         {
             // Something went wrong (maybe not a support project type), so don't add this project
@@ -137,14 +137,14 @@ public static class AnalyzerResultExtensions
         return workspace.CurrentSolution.GetProject(projectId);
     }
 
-    private static ProjectInfo GetProjectInfo(IAnalyzerResult analyzerResult, Workspace workspace, ProjectId projectId)
+    private static Microsoft.CodeAnalysis.ProjectInfo GetProjectInfo(IAnalyzerResult analyzerResult, Workspace workspace, ProjectId projectId)
     {
         string projectName = Path.GetFileNameWithoutExtension(analyzerResult.ProjectFilePath);
         if (!TryGetSupportedLanguageName(analyzerResult.ProjectFilePath, out string languageName))
         {
             return null;
         }
-        return ProjectInfo.Create(
+        return Microsoft.CodeAnalysis.ProjectInfo.Create(
             projectId,
             VersionStamp.Create(),
             projectName,

--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -1,6 +1,7 @@
 extern alias StructuredLogger;
 using System.Collections.Concurrent;
 using System.IO;
+using Buildalyzer.IO;
 using Buildalyzer.Logging;
 using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
@@ -20,7 +21,7 @@ public class AnalyzerManager : IAnalyzerManager
 
     public IReadOnlyDictionary<string, IProjectAnalyzer> Projects => _projects;
 
-    public ILoggerFactory LoggerFactory { get; set; }
+    public ILoggerFactory? LoggerFactory { get; set; }
 
     internal ConcurrentDictionary<string, string> GlobalProperties { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -35,34 +36,36 @@ public class AnalyzerManager : IAnalyzerManager
     internal ConcurrentDictionary<Guid, string[]> WorkspaceProjectReferences = new();
 #pragma warning restore SA1401 // Fields should be private
 
-    public string SolutionFilePath { get; }
+    public string? SolutionFilePath => Solution?.Path.ToString();
 
-    public SolutionFile SolutionFile { get; }
+    [Obsolete("Use Solution instead.")]
+    public SolutionFile? SolutionFile => Solution?.Reference as SolutionFile;
 
-    public AnalyzerManager(AnalyzerManagerOptions options = null)
-        : this(null, options)
+    public SolutionInfo? Solution { get; }
+
+    public AnalyzerManager(AnalyzerManagerOptions? options = null)
+        : this(IOPath.Empty, options)
     {
     }
 
-    public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions options = null)
+    [Obsolete("Use AnalyzerManager(IOPath, AnalyzerManagerOptions) instead.")]
+    public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions? options = null)
+        : this(IOPath.Parse(solutionFilePath), options) { }
+
+    public AnalyzerManager(IOPath solutionFilePath, AnalyzerManagerOptions? options = null)
     {
         options ??= new AnalyzerManagerOptions();
         LoggerFactory = options.LoggerFactory;
 
-        if (!string.IsNullOrEmpty(solutionFilePath))
+        if (solutionFilePath.HasValue)
         {
-            SolutionFilePath = NormalizePath(solutionFilePath);
-            SolutionFile = SolutionFile.Parse(SolutionFilePath);
+            Solution = SolutionInfo.Load(solutionFilePath, p => options.ProjectFilter?.Invoke(p) ?? true);
 
-            // Initialize all the projects in the solution
-            foreach (ProjectInSolution projectInSolution in SolutionFile.ProjectsInOrder)
+            // init projects. 
+            foreach (var proj in Solution)
             {
-                if (!SupportedProjectTypes.Contains(projectInSolution.ProjectType)
-                    || (options?.ProjectFilter != null && !options.ProjectFilter(projectInSolution)))
-                {
-                    continue;
-                }
-                GetProject(projectInSolution.AbsolutePath, projectInSolution);
+                var analyzer = new ProjectAnalyzer(this, proj.Path, proj);
+                _projects.TryAdd(proj.Path.ToString(), analyzer);
             }
         }
     }
@@ -83,7 +86,10 @@ public class AnalyzerManager : IAnalyzerManager
         EnvironmentVariables[key] = value;
     }
 
-    public IProjectAnalyzer GetProject(string projectFilePath) => GetProject(projectFilePath, null);
+    [Obsolete("Use GetProject(IOPath) instead.")]
+    public IProjectAnalyzer? GetProject(string projectFilePath) => GetProject(IOPath.Parse(projectFilePath));
+
+    public IProjectAnalyzer? GetProject(IOPath projectFilePath) => GetProject(projectFilePath, null);
 
     /// <inheritdoc/>
     public IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null)
@@ -104,22 +110,21 @@ public class AnalyzerManager : IAnalyzerManager
         };
     }
 
-    private IProjectAnalyzer GetProject(string projectFilePath, ProjectInSolution projectInSolution)
+    private IProjectAnalyzer? GetProject(IOPath path, ProjectInfo? project)
     {
-        Guard.NotNull(projectFilePath);
+        Guard.NotDefault(path);
 
-        projectFilePath = NormalizePath(projectFilePath);
-        if (!File.Exists(projectFilePath))
+        if (!Guard.NotDefault(path).File()!.Exists)
         {
-            if (projectInSolution == null)
-            {
-                throw new ArgumentException($"The path {projectFilePath} could not be found.");
-            }
-            return null;
+            return project is not null
+                ? null
+                : throw new ArgumentException($"The path {path} could not be found.");
         }
-        return _projects.GetOrAdd(projectFilePath, new ProjectAnalyzer(this, projectFilePath, projectInSolution));
+
+        return _projects.GetOrAdd(path.ToString(), new ProjectAnalyzer(this, path, project));
     }
 
-    internal static string NormalizePath(string path) =>
+    [Obsolete("Use IOPath instead.")]
+    internal static string? NormalizePath(string? path) =>
         path == null ? null : Path.GetFullPath(path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar));
 }

--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -92,7 +92,7 @@ public class AnalyzerManager : IAnalyzerManager
     public IProjectAnalyzer? GetProject(IOPath projectFilePath) => GetProject(projectFilePath, null);
 
     /// <inheritdoc/>
-    public IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null)
+    public IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger>? buildLoggers = null)
     {
         binLogPath = NormalizePath(binLogPath);
         if (!File.Exists(binLogPath))

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -12,6 +12,8 @@
 ToBeReleased
 - Drop Buildalyzer.EmptyDisposable. (BREAKING)
 - Publish SBOM.
+- Introduction of SolutionInfo and ProjectInfo.
+- Marked IAnalyzerManger.SolutionFile and IAnalyzer.SolutionFilePath as obsolete.
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>
@@ -22,6 +24,7 @@ ToBeReleased
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4,)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4,)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.158" Aliases="StructuredLogger" />
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
     <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -14,7 +14,7 @@ ToBeReleased
 - Publish SBOM.
 - Introduction of SolutionInfo and ProjectInfo.
 - Marked IAnalyzerManger.SolutionFile and IAnalyzer.SolutionFilePath as obsolete.
-- Support SLXN.
+- Support SLNX.
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../package.props" />
   
@@ -14,6 +14,7 @@ ToBeReleased
 - Publish SBOM.
 - Introduction of SolutionInfo and ProjectInfo.
 - Marked IAnalyzerManger.SolutionFile and IAnalyzer.SolutionFilePath as obsolete.
+- Support SLXN.
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -19,8 +19,8 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.10.46" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.10.29" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.28" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4,)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4,)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Buildalyzer/Extensions/System.Threading.Tasks.Task.cs
+++ b/src/Buildalyzer/Extensions/System.Threading.Tasks.Task.cs
@@ -1,0 +1,22 @@
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+
+namespace System.Threading.Tasks;
+
+/// <summary>Etensions on <see cref="Task"/>.</summary>
+internal static class BuildalyzerTaskExtensions
+{
+    /// <summary>Runs a task synchronously.</summary>
+    [Pure]
+    public static TResult Sync<TResult>(this Task<TResult> task) => TaskFactory
+        .StartNew(() => task)
+        .Unwrap()
+        .GetAwaiter()
+        .GetResult();
+
+    private static readonly TaskFactory TaskFactory = new(
+        CancellationToken.None,
+        TaskCreationOptions.None,
+        TaskContinuationOptions.None,
+        TaskScheduler.Default);
+}

--- a/src/Buildalyzer/Guard.cs
+++ b/src/Buildalyzer/Guard.cs
@@ -25,6 +25,46 @@ internal static class Guard
         where T : class
         => parameter ?? throw new ArgumentNullException(paramName);
 
+    /// <summary>Throws an ArgumentException if the nullable parameter has no value, otherwise the parameter value is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T HasValue<T>(T? parameter, [CallerArgumentExpression(nameof(parameter))] string? paramName = null)
+        where T : struct
+        => parameter ?? throw new ArgumentException(Messages.ArgumentException_NullableMustHaveValue, paramName);
+
+    /// <summary>
+    /// Throws an ArgumentException if the nullable parameter has no value or the default value,
+    /// otherwise the parameter value is passed.
+    /// </summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotDefault<T>(T? parameter, [CallerArgumentExpression(nameof(parameter))] string? paramName = null)
+        where T : struct => NotDefault(HasValue(parameter, paramName), paramName);
+
+    /// <summary>Throws an ArgumentException if the parameter has the default value, otherwise the parameter value is passed.</summary>
+    /// <typeparam name="T">The type to guard; must be a structure.</typeparam>
+    /// <param name="parameter">The parameter to guard.</param>
+    /// <param name="paramName">The name of the parameter.</param>
+    /// <returns>
+    /// The guarded parameter.
+    /// </returns>
+    [DebuggerStepThrough]
+    public static T NotDefault<T>(T parameter, [CallerArgumentExpression(nameof(parameter))] string? paramName = null)
+        where T : struct
+        => parameter.Equals(default(T))
+        ? throw new ArgumentException(Messages.ArgumentException_IsDefaultValue, paramName)
+        : parameter;
+
     /// <summary>Marks the NotNull argument as being validated for not being null, to satisfy the static code analysis.</summary>
     /// <remarks>
     /// Notice that it does not matter what this attribute does, as long as
@@ -35,4 +75,11 @@ internal static class Guard
     [Conditional("Analysis")]
     [AttributeUsage(AttributeTargets.Parameter)]
     private sealed class ValidatedNotNullAttribute : Attribute;
+
+    /// <summary>Messages class to group the constants.</summary>
+    private static class Messages
+    {
+        public const string ArgumentException_IsDefaultValue = "Argument is the not initialized/default value.";
+        public const string ArgumentException_NullableMustHaveValue = "Nullable argument must have a value.";
+    }
 }

--- a/src/Buildalyzer/IAnalyzerManager.cs
+++ b/src/Buildalyzer/IAnalyzerManager.cs
@@ -1,3 +1,4 @@
+using Buildalyzer.IO;
 using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
 
@@ -5,13 +6,18 @@ namespace Buildalyzer;
 
 public interface IAnalyzerManager
 {
-    ILoggerFactory LoggerFactory { get; set; }
+    ILoggerFactory? LoggerFactory { get; set; }
 
     IReadOnlyDictionary<string, IProjectAnalyzer> Projects { get; }
 
-    SolutionFile SolutionFile { get; }
+    /// <inheritdoc cref="Buildalyzer.SolutionInfo" />
+    SolutionInfo? Solution { get; }
 
-    string SolutionFilePath { get; }
+    [Obsolete("Use SolutionInfo instead.")]
+    SolutionFile? SolutionFile { get; }
+
+    [Obsolete("Use SolutionInfo.Path instead.")]
+    string? SolutionFilePath { get; }
 
     /// <summary>
     /// Analyzes an MSBuild binary log file.
@@ -21,7 +27,10 @@ public interface IAnalyzerManager
     /// <returns>A dictionary of target frameworks to <see cref="AnalyzerResult"/>.</returns>
     IAnalyzerResults Analyze(string binLogPath, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers = null);
 
-    IProjectAnalyzer GetProject(string projectFilePath);
+    IProjectAnalyzer? GetProject(string projectFilePath);
+
+    [Obsolete("Use GetProject(IOPath) instead.")]
+    IProjectAnalyzer? GetProject(IOPath projectFilePath);
 
     void RemoveGlobalProperty(string key);
 

--- a/src/Buildalyzer/IProjectAnalyzer.cs
+++ b/src/Buildalyzer/IProjectAnalyzer.cs
@@ -46,7 +46,7 @@ public interface IProjectAnalyzer
     /// </summary>
     Guid ProjectGuid { get; }
 
-    ProjectInSolution ProjectInSolution { get; }
+    ProjectInSolution? ProjectInSolution { get; }
 
     string SolutionDirectory { get; }
 

--- a/src/Buildalyzer/IProjectAnalyzer.cs
+++ b/src/Buildalyzer/IProjectAnalyzer.cs
@@ -123,7 +123,7 @@ public interface IProjectAnalyzer
     IAnalyzerResults Build(string[] targetFrameworks, EnvironmentOptions environmentOptions);
 
     void AddBinaryLogger(
-        string binaryLogFilePath = null,
+        string? binaryLogFilePath = null,
         BinaryLogger.ProjectImportsCollectionMode collectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed);
 
     /// <summary>

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -23,7 +23,7 @@ internal class EventProcessor : IDisposable
 
     public IEnumerable<AnalyzerResult> Results => _results.Values;
 
-    public EventProcessor(AnalyzerManager manager, ProjectAnalyzer analyzer, IEnumerable<Microsoft.Build.Framework.ILogger> buildLoggers, IEventSource eventSource, bool analyze)
+    public EventProcessor(AnalyzerManager manager, ProjectAnalyzer analyzer, IEnumerable<Microsoft.Build.Framework.ILogger>? buildLoggers, IEventSource eventSource, bool analyze)
     {
         _manager = manager;
         _analyzer = analyzer;

--- a/src/Buildalyzer/ProjectInfo.cs
+++ b/src/Buildalyzer/ProjectInfo.cs
@@ -1,0 +1,53 @@
+using Buildalyzer.Construction;
+using Buildalyzer.IO;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+
+namespace Buildalyzer;
+
+/// <summary>Represents info about the MS Build solution file.</summary>
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed class ProjectInfo
+{
+    private ProjectInfo(object reference, IOPath path, Guid guid, IEnumerable<string> tfms)
+    {
+        Reference = reference;
+        Path = path;
+        Guid = guid;
+        TargetFrameworks = [.. tfms];
+    }
+
+    /// <summary>The GUID of the project.</summary>
+    public Guid Guid { get; }
+
+    /// <summary>The path to the protject.</summary>
+    public IOPath Path { get; }
+
+    /// <summary>Gets the target framework(s) of the project.</summary>
+    public ImmutableArray<string> TargetFrameworks { get; }
+
+    /// <summary>Gets the reference object.</summary>
+    public object Reference { get; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => $"{Path.File()?.Name}, TFM = {string.Join(", ", TargetFrameworks)}";
+
+    [Pure]
+    internal static ProjectInfo New(ProjectInSolution proj)
+    {
+        var path = IOPath.Parse(Guard.NotNull(proj).AbsolutePath);
+        var reference = new ProjectFile(path.ToString());
+        var guid = Guid.Parse(proj.ProjectGuid);
+        return new(reference, path, guid, reference.TargetFrameworks);
+    }
+
+    [Pure]
+    internal static ProjectInfo New(SolutionProjectModel reference, IOPath root)
+    {
+        var path = root.Combine(Guard.NotNull(reference).FilePath);
+        var prop = reference.FindProperties("TargetFrameworks")
+            ?? reference.FindProperties("TargetFramework");
+
+        return new(reference, path, reference.Id, prop?.Values ?? []);
+    }
+}

--- a/src/Buildalyzer/SolutionInfo.cs
+++ b/src/Buildalyzer/SolutionInfo.cs
@@ -1,0 +1,85 @@
+#pragma warning disable CA1710 // Identifiers should have correct suffix: being a collection is not its main purpose.
+
+using System.Threading.Tasks;
+using Buildalyzer.IO;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
+
+namespace Buildalyzer;
+
+/// <summary>Represents info about the MS Build solution file.</summary>
+[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView<ProjectInfo>))]
+[DebuggerDisplay("{Path.File().Name}, Count = {Count}")]
+public sealed class SolutionInfo : IReadOnlyCollection<ProjectInfo>
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Dictionary<Guid, ProjectInfo> Lookup;
+
+    private SolutionInfo(object reference, IOPath path, IEnumerable<ProjectInfo> projects)
+    {
+        Reference = reference;
+        Path = path;
+        Projects = [.. projects];
+        Lookup = Projects.ToDictionary(p => p.Guid, p => p);
+    }
+
+    /// <summary>The path to the solution.</summary>
+    public IOPath Path { get; }
+
+    /// <summary>The projects in the solution.</summary>
+    public ImmutableArray<ProjectInfo> Projects { get; }
+
+    /// <summary>Tries to get a project based on its <see cref="ProjectInfo.Guid"/>.</summary>
+    public ProjectInfo? this[Guid projectGuid] => Lookup[projectGuid];
+
+    /// <summary>Gets the reference object.</summary>
+    public object Reference { get; }
+
+    /// <inheritdoc />
+    public int Count => Projects.Length;
+
+    /// <inheritdoc />
+    [Pure]
+    public IEnumerator<ProjectInfo> GetEnumerator() => ((IReadOnlyCollection<ProjectInfo>)Projects).GetEnumerator();
+
+    /// <inheritdoc />
+    [Pure]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>Loads the <see cref="SolutionInfo"/> from disk.</summary>
+    /// <param name="path">
+    /// The path to load from.
+    /// </param>
+    /// <param name="filter">
+    /// The project to include.
+    /// </param>
+    [Pure]
+    public static SolutionInfo Load(IOPath path, Predicate<ProjectInSolution>? filter = null)
+        => path.ToString().IsMatchEnd(".slnx")
+        ? LoadSlnx(path)
+        : LoadSln(path, filter);
+
+    /// <summary>Loads the SLNX.</summary>
+    [Pure]
+    private static SolutionInfo LoadSlnx(IOPath path)
+    {
+        var serilizer = SolutionSerializers.GetSerializerByMoniker(path.ToString())!;
+        var solution = serilizer.OpenAsync(path.ToString(), default).Sync();
+        var root = IOPath.Parse(path.File()?.Directory?.FullName);
+        var projects = solution.SolutionProjects.Select(p => ProjectInfo.New(p, root));
+
+        return new(solution, path, projects);
+    }
+
+    /// <summary>Loads the SLN.</summary>
+    [Pure]
+    private static SolutionInfo LoadSln(IOPath path, Predicate<ProjectInSolution>? filter)
+    {
+        var reference = SolutionFile.Parse(path.ToString());
+        var projects = reference.ProjectsInOrder
+           .Where(p => (filter?.Invoke(p) ?? true) && System.IO.File.Exists(p.AbsolutePath))
+           .Select(ProjectInfo.New);
+
+        return new(reference, path, projects);
+    }
+}

--- a/tests/Buildalyzer.Tests/Integration/Solution_specs.cs
+++ b/tests/Buildalyzer.Tests/Integration/Solution_specs.cs
@@ -19,6 +19,20 @@ public class Resolves
         results.Single().ProjectGuid.Should().Be("016713d9-b665-4272-9980-148801a9b88f");
     }
 
+    [Test]
+    public void Project_GUID_from_SLNX([ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        using var ctx = Context.ForSolution("TestProjects.slnx");
+
+        ctx.Manager.Projects.Should().HaveCount(30);
+
+        var analyzer = ctx.Manager.Projects.First(x => x.Key.EndsWith("SdkNetStandardProject.csproj")).Value;
+
+        var results = analyzer.Build(new EnvironmentOptions { Preference = preference });
+
+        results.Single().ProjectGuid.Should().Be("afc5f1d6-f485-9d71-eb6f-2af9bd127256");
+    }
+
     /// <remarks>
     /// Builds a lot of projects that should all succeed.
     /// </remarks>

--- a/tests/projects/TestProjects.slnx
+++ b/tests/projects/TestProjects.slnx
@@ -1,0 +1,32 @@
+<Solution>
+  <Project Path="AzureFunctionProject/AzureFunctionProject.csproj" />
+  <Project Path="FSharpProject/FSharpProject.fsproj" />
+  <Project Path="LegacyFrameworkProject/LegacyFrameworkProject.csproj" Id="36ed2b9d-2fc2-4725-9bc2-53cabf113477" />
+  <Project Path="LegacyFrameworkProjectWithPackageReference/LegacyFrameworkProjectWithPackageReference.csproj" Id="cd3445e2-a34a-4d87-9e8a-5081cbfa2f86" />
+  <Project Path="LegacyFrameworkProjectWithReference/LegacyFrameworkProjectWithReference.csproj" Id="d1f5ad80-aded-4286-8fa4-3a8a6e818d34" />
+  <Project Path="RazorClassLibraryTest/RazorClassLibraryTest.csproj" />
+  <Project Path="ResponseFile/ResponseFile.csproj" />
+  <Project Path="SdkFrameworkProject/SdkFrameworkProject.csproj" />
+  <Project Path="SdkMultiTargetingProject/SdkMultiTargetingProject.csproj" />
+  <Project Path="SdkNet5Project/SdkNet5Project.csproj" />
+  <Project Path="SdkNet6Exe/SdkNet6Exe.csproj" />
+  <Project Path="SdkNet6ImplicitUsings/SdkNet6ImplicitUsings.csproj" />
+  <Project Path="SdkNet6Project/SdkNet6Project.csproj" />
+  <Project Path="SdkNet6SelfContained/SdkNet6SelfContained.csproj" />
+  <Project Path="SdkNet7Project/SdkNet7Project.csproj" />
+  <Project Path="SdkNet8Alias/SdkNet8Alias.csproj" />
+  <Project Path="SdkNet8CS12FeaturesProject/SdkNet8CS12FeaturesProject.csproj" />
+  <Project Path="SdkNetCore2Project/SdkNetCore2Project.csproj" />
+  <Project Path="SdkNetCore2ProjectImport/SdkNetCore2ProjectImport.csproj" />
+  <Project Path="SdkNetCore2ProjectWithAnalyzer/SdkNetCore2ProjectWithAnalyzer.csproj" />
+  <Project Path="SdkNetCore2ProjectWithImportedProps/SdkNetCore2ProjectWithImportedProps.csproj" />
+  <Project Path="SdkNetCore2ProjectWithReference/SdkNetCore2ProjectWithReference.csproj" />
+  <Project Path="SdkNetCore31Project/SdkNetCore31Project.csproj" />
+  <Project Path="SdkNetStandardProject/SdkNetStandardProject.csproj" />
+  <Project Path="SdkNetStandardProjectImport/SdkNetStandardProjectImport.csproj" />
+  <Project Path="SdkNetStandardProjectWithConstants/SdkNetStandardProjectWithConstants.csproj" />
+  <Project Path="SdkNetStandardProjectWithPackageReference/SdkNetStandardProjectWithPackageReference.csproj" />
+  <Project Path="TransitiveProjectReference/TransitiveProjectReference.csproj" />
+  <Project Path="VisualBasicProject/VisualBasicNetConsoleApp.vbproj" />
+  <Project Path="WpfCustomControlLibrary1/WpfCustomControlLibrary1.csproj" Id="aed0d0e7-7312-49a9-a439-083f34286286" />
+</Solution>


### PR DESCRIPTION
Both `SolutionInfo` and `ProjectInfo` are immutable objects, describing the solution and its projects under analysis. They reflect the information resolved by calling MS's `SolutionFile`, and our own `ProjectFile`. As a result two properties of `IAnalyzerManager` are marked as obsolete.

This should also close #303

Before this can be finished, first #316 should be completed.

As this build now fails due to the issue reported at #328, also build dependency updates are included.