### PR TITLE
Expose CompilerVisibleProperty to AnalyzerConfigOptionsProvider.GlobalOptions

### DIFF
--- a/tests/Buildalyzer.Workspaces.Tests/CompilerVisibleProperty_specs.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/CompilerVisibleProperty_specs.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Buildalyzer.TestTools;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Buildalyzer.Workspaces.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class CompilerVisibleProperty
+{
+    [Test]
+    public async Task is_exposed()
+    {
+        using var ctx = Context.ForProject(@"CompilerVisibleProperty\CompilerVisibleProperty.csproj");
+
+        using var workspace = ctx.Analyzer.GetWorkspace();
+
+        var project = workspace.CurrentSolution.Projects.Single();
+
+        var compilation = await project.GetCompilationAsync();
+        var options = compilation!.Options.WithSpecificDiagnosticOptions([KeyValuePair.Create("TEST01", ReportDiagnostic.Warn)]);
+
+        var diagnostics = await compilation
+            .WithOptions(options)
+            .WithAnalyzers([new ReportCustomProperty()])
+            .GetAllDiagnosticsAsync(default);
+
+        diagnostics[^1].ToString().Should().BeEquivalentTo("warning TEST01: Has custom property with value 'Custom value'");
+    }
+}
+
+#pragma warning disable
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+file sealed class ReportCustomProperty : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = new(
+        id: "TEST01",
+        title: "Has custom property",
+        messageFormat: "Has custom property with value '{0}'",
+        category: "Test",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context) => context.RegisterCompilationAction(Report);
+
+    private static void Report(CompilationAnalysisContext context)
+    {
+        var value = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue("build_property.CustomProperty", out var v)
+            ? v
+            : null;
+
+        var issue = Diagnostic.Create(Descriptor, null, value);
+        context.ReportDiagnostic(issue);
+    }
+}

--- a/tests/projects/CompilerVisibleProperty/CompilerVisibleProperty.csproj
+++ b/tests/projects/CompilerVisibleProperty/CompilerVisibleProperty.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CustomProperty>Custom value</CustomProperty>
+  </PropertyGroup>
+
+ <ItemGroup>
+   <CompilerVisibleProperty Include="CustomProperty" />
+ </ItemGroup>
+ 
+</Project>


### PR DESCRIPTION
When creating a `.csproj` file:

``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <CustomProperty>Custom value</CustomProperty>
  </PropertyGroup>

 <ItemGroup>
   <CompilerVisibleProperty Include="CustomProperty" />
 </ItemGroup>
 
</Project>
````

The value of the `<CustomProperty>` is exposed to the `AnalyzerConfigOptionsProvider.GlobalOptions` within the context of a Roslyn code analyzer. How Roslyn solves this is as follows:

It generates an `.editorcofig` file with the name: `obj/{Configuratioin}/{TargetFrameWork}/{ProjectFileName}.GeneratedMSBuildEditorConfig.editorconfig`.

In the reproducer this is the body:

``` ini
is_global = true
build_property.CustomProperty = Custom value
build_property.TargetFramework = net8.0
build_property.TargetPlatformMinVersion = 
build_property.UsingMicrosoftNETSdkWeb = 
build_property.ProjectTypeGuids = 
build_property.InvariantGlobalization = 
build_property.PlatformNeutralAssembly = 
build_property.EnforceExtendedAnalyzerRules = 
build_property._SupportedPlatformList = Linux,macOS,Windows
build_property.RootNamespace = CompilerVisibleProperty
build_property.ProjectDir = ~\buildalyzer\tests\projects\CompilerVisibleProperty\
build_property.EnableComHosting = 
build_property.EnableGeneratedComInterfaceComImportInterop = 
build_property.EffectiveAnalysisLevelStyle = 8.0
build_property.EnableCodeStyleSeverity = 
```

To actually solve this, this file has to be added to the `AnalyzerConfig` somehow. I'm not sure if this can be achieved in Buildalyzer, or that it is only possible to do this when spinning up the diagnostics.