### PR TITLE
Handle version child element in PackageReference parsing

### DIFF
--- a/src/Buildalyzer/Construction/PackageReference.cs
+++ b/src/Buildalyzer/Construction/PackageReference.cs
@@ -12,6 +12,6 @@ public class PackageReference : IPackageReference
         this.Name = packageReferenceElement.GetAttributeValue("Include") ?? packageReferenceElement.GetAttributeValue("Update");
         var versionElement = packageReferenceElement.DescendantsAndSelf()
             .FirstOrDefault(x => x.Name.LocalName == "Version");
-        this.Version = versionElement?.Value ?? packageReferenceElement.GetAttributeValue("Version");
+        this.Version = packageReferenceElement.GetAttributeValue("Version") ?? versionElement?.Value;
     }
 }

--- a/src/Buildalyzer/Construction/PackageReference.cs
+++ b/src/Buildalyzer/Construction/PackageReference.cs
@@ -10,6 +10,8 @@ public class PackageReference : IPackageReference
     internal PackageReference(XElement packageReferenceElement)
     {
         this.Name = packageReferenceElement.GetAttributeValue("Include") ?? packageReferenceElement.GetAttributeValue("Update");
-        this.Version = packageReferenceElement.GetAttributeValue("Version");
+        var versionElement = packageReferenceElement.DescendantsAndSelf()
+            .FirstOrDefault(x => x.Name.LocalName == "Version");
+        this.Version = versionElement?.Value ?? packageReferenceElement.GetAttributeValue("Version");
     }
 }

--- a/tests/Buildalyzer.Tests/Construction/PackageReferenceFixture.cs
+++ b/tests/Buildalyzer.Tests/Construction/PackageReferenceFixture.cs
@@ -45,4 +45,21 @@ public class PackageReferenceFixture
         // Then
         packageReference.Name.ShouldBe("UpdatedDependency");
     }
+
+    [Test]
+    public void PackageReferenceWithVersionChildElementShouldContainVersion()
+    {
+        // Given
+        XElement xml = XElement.Parse(@"
+            <PackageReference Include=""IncludedDependency"">
+                <Version>4.0.0</Version>
+            </PackageReference>
+        ");
+
+        // When
+        PackageReference packageReference = new PackageReference(xml);
+
+        // Then
+        packageReference.Version.ShouldBe("4.0.0");
+    }
 }


### PR DESCRIPTION
### 🚀 Pull Request Template

## Description
This PR updates the PackageReference constructor to include the version if found in a child element instead of the XElement attribute during parsing.

Added a corresponding test case in the PackageReferenceFixture file.

*If it is a draft, describe the next steps
*Remember to create tests whenever possible