### PR TITLE
Alternative to the EventProcessor

### DIFF
--- a/src/Buildalyzer/BuildAnalysis.cs
+++ b/src/Buildalyzer/BuildAnalysis.cs
@@ -1,0 +1,56 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer;
+
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView<ProjectAnalysis>))]
+public sealed class BuildAnalysis(ImmutableArray<ProjectAnalysis> projects) :
+    IReadOnlyCollection<ProjectAnalysis>,
+    IAnalyzerResults
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public readonly ImmutableArray<ProjectAnalysis> Projects = projects;
+
+    IAnalyzerResult IAnalyzerResults.this[string targetFramework] => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public int Count => Projects.Length;
+
+    ImmutableArray<BuildEventArgs> IAnalyzerResults.BuildEventArguments =>
+    [
+        .. Projects.SelectMany(p => p.Events)
+    ];
+
+    bool IAnalyzerResults.OverallSuccess => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    IEnumerable<IAnalyzerResult> IAnalyzerResults.Results
+        => Projects.Where(p => p.Command is { } && p.TargetFramework is { Length: > 0 });
+
+    IEnumerable<string> IAnalyzerResults.TargetFrameworks => throw new NotImplementedException();
+
+    int IReadOnlyCollection<IAnalyzerResult>.Count => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    [Pure]
+    public IEnumerator<ProjectAnalysis> GetEnumerator() => Projects.AsEnumerable().GetEnumerator();
+
+    bool IAnalyzerResults.ContainsTargetFramework(string targetFramework)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    [Pure]
+    IEnumerator IEnumerable.GetEnumerator()=> GetEnumerator();
+
+    IEnumerator<IAnalyzerResult> IEnumerable<IAnalyzerResult>.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    bool IAnalyzerResults.TryGetTargetFramework(string targetFramework, out IAnalyzerResult result)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Buildalyzer/BuildEventArgsCollector.cs
+++ b/src/Buildalyzer/BuildEventArgsCollector.cs
@@ -21,25 +21,34 @@ internal sealed class BuildEventArgsCollector : IReadOnlyCollection<BuildEventAr
     public bool IsEmpty => Count == 0;
 
     /// <inheritdoc />
-    public IEnumerator<BuildEventArgs> GetEnumerator() => Bag.GetEnumerator();
+    /// <remarks>
+    /// Ordered by timestamp, as the bag does not ensure the chronical order itself.
+    /// </remarks>
+    [Pure]
+    public IEnumerator<BuildEventArgs> GetEnumerator() => Bag.OrderBy(e => e.Timestamp).GetEnumerator();
 
     /// <inheritdoc />
+    [Pure]
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     private void EventRaised(object? sender, BuildEventArgs e) => Bag.Add(e);
 
     private readonly EventArgsDispatcher Server;
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly ConcurrentBag<BuildEventArgs> Bag = [];
 
+    /// <inheritdoc />
     public void Dispose()
     {
         if (!Disposed)
         {
             Server.AnyEventRaised -= EventRaised;
+            Bag.Clear();
             Disposed = true;
         }
     }
 
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private bool Disposed;
 }

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../package.props" />
   

--- a/src/Buildalyzer/Compiler/Compiler.cs
+++ b/src/Buildalyzer/Compiler/Compiler.cs
@@ -105,6 +105,7 @@ public static class Compiler
                 SourceFiles = [.. arguments.SourceFiles.Select(AsIOPath)],
                 AdditionalFiles = [.. arguments.AdditionalFiles.Select(AsIOPath)],
                 EmbeddedFiles = [.. arguments.EmbeddedFiles.Select(AsIOPath)],
+                Errors = arguments.Errors,
             };
     }
 

--- a/src/Buildalyzer/Extensions/Buildalyzer.Handling.BuildEventProcessorContext.cs
+++ b/src/Buildalyzer/Extensions/Buildalyzer.Handling.BuildEventProcessorContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+internal static class BuildEventProcessorContextExtensions
+{
+    internal static ProjectAnalysis Get(this BuildEventHandlerContext context, BuildEventArgs args)
+    {
+        var projectId = args.BuildEventContext!.ProjectInstanceId;
+        return Guard.NotNull(context).Projects.TryGetValue(projectId, out var existing)
+            ? existing : new ProjectAnalysis() { ProjectId = projectId };
+    }
+
+    internal static void Set(this BuildEventHandlerContext context, ProjectAnalysis analysis)
+    {
+        Guard.NotNull(context).Projects[analysis.ProjectId] = analysis;
+    }
+
+    internal static void Update(this BuildEventHandlerContext context, BuildEventArgs args, Func<ProjectAnalysis, ProjectAnalysis> transform)
+    {
+        var project = Guard.NotNull(context).Get(args);
+        context.Projects[project.ProjectId] = transform(project);
+    }
+}

--- a/src/Buildalyzer/Handling/BuildErrorHandler.cs
+++ b/src/Buildalyzer/Handling/BuildErrorHandler.cs
@@ -1,0 +1,15 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the <see cref="BuildErrorEventArgs"/> build event.</summary>
+public sealed class BuildErrorHandler : BuildEventHandlerBase<BuildErrorEventArgs>
+{
+    /// <inheritdoc />
+    protected override void Apply(BuildErrorEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis => analysis with
+        {
+            Errors = analysis.Errors.Add(e),
+            Events = analysis.Events.Add(e),
+        });
+}

--- a/src/Buildalyzer/Handling/BuildEventHandler.cs
+++ b/src/Buildalyzer/Handling/BuildEventHandler.cs
@@ -1,0 +1,13 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handler for <see cref="BuildEventArgs"/>.</summary>
+public interface BuildEventHandler
+{
+    /// <summary>Handles the <see cref="BuildEventArgs"/>.</summary>
+    /// <returns>
+    /// An indiciation if the handler could handle the provided args.
+    /// </returns>
+    bool Handle(BuildEventArgs args, BuildEventHandlerContext context);
+}

--- a/src/Buildalyzer/Handling/BuildEventHandlerBase.cs
+++ b/src/Buildalyzer/Handling/BuildEventHandlerBase.cs
@@ -1,0 +1,31 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Provides a base implementation for <see cref="BuildEventHandler"/>.</summary>
+/// <typeparam name="TEvent">
+/// The concrete type of the <see cref="BuildEventArgs"/>.
+/// </typeparam>
+public abstract class BuildEventHandlerBase<TEvent> : BuildEventHandler
+    where TEvent : BuildEventArgs
+{
+    /// <inheritdoc />
+    public bool Handle(BuildEventArgs args, BuildEventHandlerContext context)
+    {
+        if (args is TEvent @event && CanHandle(@event, context))
+        {
+            Apply(@event, context);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Indicates if event can be handled by the handler.</summary>
+    protected virtual bool CanHandle(TEvent e, BuildEventHandlerContext context) => true;
+
+    /// <summary>Applies the event to the context.</summary>
+    protected abstract void Apply(TEvent e, BuildEventHandlerContext context);
+}

--- a/src/Buildalyzer/Handling/BuildEventHandlerContext.cs
+++ b/src/Buildalyzer/Handling/BuildEventHandlerContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+public class BuildEventHandlerContext
+{
+    public ImmutableArray<BuildEventArgs> Events { get; } = [];
+
+    public Dictionary<int, ProjectAnalysis> Projects { get; } = [];
+
+    public List<BuildEventArgs> Skipped { get; } = [];
+}

--- a/src/Buildalyzer/Handling/BuildEventHandlers.cs
+++ b/src/Buildalyzer/Handling/BuildEventHandlers.cs
@@ -1,0 +1,49 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+public static class BuildEventHandlers
+{
+    public static readonly ImmutableArray<BuildEventHandler> Default =
+    [
+        new BuildErrorHandler(),
+        new CSharpBuildCommandHandler(),
+        new FSharpBuildCommandHandler(),
+        new VisualBasicBuildCommandHandler(),
+        new ProjectStartedHandler(),
+        new ProjectFinshedHandler(),
+        new TargetStartedHandler(),
+    ];
+
+    /// <summary>Handles events.</summary>
+    /// <param name="handlers">
+    /// The handlers to use.
+    /// </param>
+    /// <param name="events">
+    /// The events to apply.
+    /// </param>
+    /// <param name="context">
+    /// The handler context.
+    /// </param>
+    [Pure]
+    public static ImmutableArray<ProjectAnalysis> Handle(
+        this IReadOnlyCollection<BuildEventHandler> handlers,
+        IEnumerable<BuildEventArgs> events,
+        BuildEventHandlerContext? context = null)
+    {
+        Guard.NotNull(handlers);
+        Guard.NotNull(events);
+
+        context ??= new BuildEventHandlerContext();
+
+        foreach (var e in events)
+        {
+            // Apply the first match only.
+            if (handlers.FirstOrDefault(h => h.Handle(e, context)) is null)
+            {
+                context.Skipped.Add(e);
+            }
+        }
+        return [.. context.Projects.Values];
+    }
+}

--- a/src/Buildalyzer/Handling/CSharpBuildCommandHandler.cs
+++ b/src/Buildalyzer/Handling/CSharpBuildCommandHandler.cs
@@ -1,0 +1,25 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the CSC (C#) build event.</summary>
+public sealed class CSharpBuildCommandHandler : BuildEventHandlerBase<TaskCommandLineEventArgs>
+{
+    /// <inheritdoc />
+    protected override bool CanHandle(TaskCommandLineEventArgs e, BuildEventHandlerContext context)
+        => e.CommandLine is { Length: > 0 }
+        && e.TaskName.IsMatch("CSC");
+
+    /// <inheritdoc />
+    protected override void Apply(TaskCommandLineEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis =>
+        {
+            var command = Compiler.CommandLine.Parse(analysis.ProjectFile.File()?.Directory, e.CommandLine, CompilerLanguage.CSharp);
+
+            return analysis with
+            {
+                Command = command,
+                Events = analysis.Events.Add(e),
+            };
+        });
+    }

--- a/src/Buildalyzer/Handling/FSharpBuildCommandHandler.cs
+++ b/src/Buildalyzer/Handling/FSharpBuildCommandHandler.cs
@@ -1,0 +1,31 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the FSC (F#) build event.</summary>
+public sealed class FSharpBuildCommandHandler : BuildEventHandlerBase<BuildMessageEventArgs>
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// The check on <see cref="FSharpCommandLineParser.SplitCommandLineIntoArguments(string?)"/>
+    /// is performed to filter out messages similar to:
+    /// Microsoft (R) F# Compiler version 13.9.300.0 for F# 9.0
+    /// Which are communicated on TargetName = restore.
+    /// </remarks>
+    protected override bool CanHandle(BuildMessageEventArgs e, BuildEventHandlerContext context)
+        => e.SenderName.IsMatch("FSC")
+        && FSharpCommandLineParser.SplitCommandLineIntoArguments(e.Message) is { Length: > 0 };
+
+    /// <inheritdoc />
+    protected override void Apply(BuildMessageEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis =>
+        {
+            var command = Compiler.CommandLine.Parse(analysis.ProjectFile.File()?.Directory, e.Message!, CompilerLanguage.FSharp);
+
+            return analysis with
+            {
+                Command = command,
+                Events = analysis.Events.Add(e),
+            };
+        });
+}

--- a/src/Buildalyzer/Handling/ProjectEvaluationFinishedHandler.cs
+++ b/src/Buildalyzer/Handling/ProjectEvaluationFinishedHandler.cs
@@ -1,0 +1,23 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the <see cref="ProjectEvaluationFinishedEventArgs"/> build event.</summary>
+public sealed class ProjectEvaluationFinishedHandler : BuildEventHandlerBase<ProjectEvaluationFinishedEventArgs>
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// In binlog 14 we need to gather properties and items during evaluation
+    /// and "glue" them with the project event args But can never remove
+    /// <see cref="ProjectStartedEventArgs"/>:
+    /// "even v14 will log them on ProjectStarted if any legacy loggers are present (for compat)"
+    /// See https://twitter.com/KirillOsenkov/status/1427686459713019904.
+    /// </remarks>
+    protected override void Apply(ProjectEvaluationFinishedEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis => analysis with
+        {
+            Properties = CompilerProperties.FromDictionaryEntries(e.Properties),
+            Items = CompilerItemsCollection.FromDictionaryEntries(e.Items),
+            Events = analysis.Events.Add(e),
+        });
+}

--- a/src/Buildalyzer/Handling/ProjectFinshedHandler.cs
+++ b/src/Buildalyzer/Handling/ProjectFinshedHandler.cs
@@ -1,0 +1,14 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the <see cref="ProjectFinishedEventArgs"/> build event.</summary>
+public sealed class ProjectFinshedHandler : BuildEventHandlerBase<ProjectFinishedEventArgs>
+{
+    protected override void Apply(ProjectFinishedEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis => analysis with
+        {
+            Succeeded = e.Succeeded && analysis.Errors.Length is 0,
+            Finished = e.Timestamp,
+        });
+}

--- a/src/Buildalyzer/Handling/ProjectStartedHandler.cs
+++ b/src/Buildalyzer/Handling/ProjectStartedHandler.cs
@@ -1,0 +1,44 @@
+using Buildalyzer.Construction;
+using Buildalyzer.IO;
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the <see cref="ProjectStartedEventArgs"/> build event.</summary>
+public sealed class ProjectStartedHandler : BuildEventHandlerBase<ProjectStartedEventArgs>
+{
+    /// <inheritdoc />
+    protected override void Apply(ProjectStartedEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis =>
+        {
+            var projectFile = IOPath.Parse(e.ProjectFile) is { HasValue: true } pf ? pf : analysis.ProjectFile;
+
+            var properties = analysis.Properties.Count > 0
+                ? analysis.Properties
+                : CompilerProperties.FromDictionaryEntries(e.Properties);
+
+            var items = analysis.Items.Count > 0
+                ? analysis.Items
+                : CompilerItemsCollection.FromDictionaryEntries(e.Items);
+
+            var tfm = properties.TryGet(ProjectFileNames.TargetFramework)
+                ?? properties.TryGet(ProjectFileNames.TargetFrameworkIdentifier)
+                ?? properties.TryGet(ProjectFileNames.TargetFrameworkVersion);
+
+            // Restore is not communicated via TargetStarted, but is important to know.
+            var targetName = analysis.TargetName is null && e.TargetNames is "Restore"
+                ? e.TargetNames
+                : analysis.TargetName;
+
+            return analysis with
+            {
+                ProjectFile = projectFile,
+                Properties = properties,
+                Items = items,
+                TargetFramework = tfm is { } prop ? prop.StringValue : null,
+                TargetName = targetName,
+                Started = e.Timestamp,
+                Events = analysis.Events.Add(e),
+            };
+        });
+}

--- a/src/Buildalyzer/Handling/TargetStartedHandler.cs
+++ b/src/Buildalyzer/Handling/TargetStartedHandler.cs
@@ -1,0 +1,11 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the <see cref="TargetStartedEventArgs"/> build event.</summary>
+public sealed class TargetStartedHandler : BuildEventHandlerBase<TargetStartedEventArgs>
+{
+    /// <inheritdoc />
+    protected override void Apply(TargetStartedEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis => analysis with { TargetName = e.TargetName });
+}

--- a/src/Buildalyzer/Handling/VisualBasicBuildCommandHandler.cs
+++ b/src/Buildalyzer/Handling/VisualBasicBuildCommandHandler.cs
@@ -1,0 +1,25 @@
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer.Handling;
+
+/// <summary>Handles the VBC (VB.NET) build event.</summary>
+public sealed class VisualBasicBuildCommandHandler : BuildEventHandlerBase<TaskCommandLineEventArgs>
+{
+    /// <inheritdoc />
+    protected override bool CanHandle(TaskCommandLineEventArgs e, BuildEventHandlerContext context)
+        => e.CommandLine is { Length: > 0 }
+        && e.TaskName.IsMatch("VBC");
+
+    /// <inheritdoc />
+    protected override void Apply(TaskCommandLineEventArgs e, BuildEventHandlerContext context)
+        => context.Update(e, analysis =>
+        {
+            var command = Compiler.CommandLine.Parse(analysis.ProjectFile.File()?.Directory, e.CommandLine, CompilerLanguage.VisualBasic);
+
+            return analysis with
+            {
+                Command = command,
+                Events = analysis.Events.Add(e),
+            };
+        });
+}

--- a/src/Buildalyzer/ProjectAnalysis.cs
+++ b/src/Buildalyzer/ProjectAnalysis.cs
@@ -1,0 +1,100 @@
+using Buildalyzer.IO;
+using Microsoft.Build.Framework;
+
+namespace Buildalyzer;
+
+public record ProjectAnalysis : IAnalyzerResult
+{
+    /// <summary>
+    /// The projectId, commenly resolved from <see cref="ProjectStartedEventArgs.ProjectId"/>.
+    /// </summary>
+    public int ProjectId { get; init; }
+
+    /// <summary>The project file (location).</summary>
+    public IOPath ProjectFile { get; init; }
+
+    /// <summary>The parsed compiler command.</summary>
+    public CompilerCommand? Command { get; init; }
+
+    /// <summary>The compiler properties.</summary>
+    public CompilerProperties Properties { get; init; } = CompilerProperties.Empty;
+
+    /// <summary>The compiler items.</summary>
+    public CompilerItemsCollection Items { get; init; } = CompilerItemsCollection.Empty;
+
+    /// <summary>The target framework of the project compilation.</summary>
+    public string? TargetFramework { get; init; }
+
+    /// <summary>The target name of the project.</summary>
+    public string? TargetName { get; init; }
+
+    /// <summary>Indiciated if the build succeeded (null if not finalized).</summary>
+    public bool? Succeeded { get; init; }
+
+    /// <summary>Start time.</summary>
+    public DateTime Started { get; init; }
+
+    /// <summary>Finihs time.</summary>
+    public DateTime Finished { get; init; }
+
+    /// <summary>Gets the duration of the build.</summary>
+    public TimeSpan Duration => Finished - Started;
+
+    ///// <summary>The compiled source files.</summary>
+    //public ImmutableArray<IOPath> SourceFiles { get; init; } = [];
+
+    ///// <summary>The available addtional files for further analysis.</summary>
+    //public ImmutableArray<IOPath> AdditionalFiles { get; init; } = [];
+
+    ///// <summary>The available embedded files for further analysis.</summary>
+    //public ImmutableArray<IOPath> EmbeddedFiles { get; init; } = [];
+
+    /// <summary>Build errors.</summary>
+    public ImmutableArray<BuildErrorEventArgs> Errors { get; init; } = [];
+
+    /// <summary>Involved events.</summary>
+    public ImmutableArray<BuildEventArgs> Events { get; init; } = [];
+
+    ProjectAnalyzer IAnalyzerResult.Analyzer => null!;
+
+    IReadOnlyDictionary<string, IProjectItem[]> IAnalyzerResult.Items => throw new NotImplementedException();
+
+    AnalyzerManager IAnalyzerResult.Manager => throw new NotImplementedException();
+
+    IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> IAnalyzerResult.PackageReferences => throw new NotImplementedException();
+
+    string IAnalyzerResult.ProjectFilePath => throw new NotImplementedException();
+
+    Guid IAnalyzerResult.ProjectGuid => throw new NotImplementedException();
+
+    IEnumerable<string> IAnalyzerResult.ProjectReferences => throw new NotImplementedException();
+
+    IReadOnlyDictionary<string, string> IAnalyzerResult.Properties => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.References => throw new NotImplementedException();
+
+    ImmutableDictionary<string, ImmutableArray<string>> IAnalyzerResult.ReferenceAliases => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.AnalyzerReferences => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.SourceFiles => throw new NotImplementedException();
+
+    bool IAnalyzerResult.Succeeded => throw new NotImplementedException();
+
+    string IAnalyzerResult.TargetFramework => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.PreprocessorSymbols => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.AdditionalFiles => throw new NotImplementedException();
+
+    string IAnalyzerResult.Command => throw new NotImplementedException();
+
+    string IAnalyzerResult.CompilerFilePath => throw new NotImplementedException();
+
+    string[] IAnalyzerResult.CompilerArguments => throw new NotImplementedException();
+
+    string IAnalyzerResult.GetProperty(string name)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
+++ b/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
@@ -1,4 +1,5 @@
 using Buildalyzer.Environment;
+using Buildalyzer.Handling;
 using Buildalyzer.TestTools;
 
 namespace Failing_builds;
@@ -10,6 +11,11 @@ public class Analyzer_Build
     {
         using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.csproj");
         var results = ctx.Analyzer.Build(new EnvironmentOptions() { DesignTime = false });
+
+        var summeries = BuildEventHandlers.Default.Handle(results.BuildEventArguments);
+        var summary = summeries.Single(s => s.Command!.SourceFiles.Any());
+
+        summary.Errors.Should().HaveCount(3);
 
         results.OverallSuccess.Should().BeFalse();
         results.Should().AllSatisfy(r => r.Succeeded.Should().BeFalse());

--- a/tests/Buildalyzer.Tests/TestTools/Context.cs
+++ b/tests/Buildalyzer.Tests/TestTools/Context.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
+using Buildalyzer.Environment;
 
 namespace Buildalyzer.TestTools;
 
@@ -25,6 +26,9 @@ public abstract class Context : IDisposable
             "projects",
             file));
     }
+
+    [Pure]
+    public abstract BuildAnalysis Build(EnvironmentOptions? options = null);
 
     protected Context(FileInfo location, Func<Context, AnalyzerManager> manager)
     {

--- a/tests/Buildalyzer.Tests/TestTools/ProjectFileTestContext.cs
+++ b/tests/Buildalyzer.Tests/TestTools/ProjectFileTestContext.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
 using System.IO;
+using Buildalyzer.Environment;
+using Buildalyzer.Handling;
+using Grammr;
 
 namespace Buildalyzer.TestTools;
 
@@ -21,6 +24,13 @@ public sealed class ProjectFileTestContext : Context
     }
 
     public IProjectAnalyzer Analyzer { get; }
+
+    public override BuildAnalysis Build(EnvironmentOptions? options = null)
+    {
+        var results = Analyzer.Build(options ?? new EnvironmentOptions() { DesignTime = false });
+        var analysis = BuildEventHandlers.Default.Handle(results.BuildEventArguments);
+        return new BuildAnalysis(analysis);
+    }
 
     [Conditional("BinaryLog")]
     internal void AddBinaryLogger(IProjectAnalyzer analyzer)

--- a/tests/Buildalyzer.Tests/TestTools/SolutionFileTestContext.cs
+++ b/tests/Buildalyzer.Tests/TestTools/SolutionFileTestContext.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Buildalyzer.Environment;
 
 namespace Buildalyzer.TestTools;
 
@@ -19,5 +20,10 @@ public sealed class SolutionFileTestContext : Context
             return new(solutionFile.FullName, options);
         })
     {
+    }
+
+    public override BuildAnalysis Build(EnvironmentOptions? options = null)
+    {
+        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
With #296 we publicly exposed all `BuildEventArgs` collected during a build. With this PR I implemented an alternative `EventProcssor` that processes the `BuildEventArgs` afterwards. This allows scenarios as desired by #278: By adding/replacing handlers the outcome can be tweaked.

I've left the `IAnalyzerResult` as is, and introduced `ProjectAnalysis`. I'm open for better naming suggestions.