### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+  name: 'Release'
+  
+  on:
+    workflow_dispatch:
+      inputs:
+        version_suffix:
+          description: Suffix of the version number. Can be used to create a preview package.
+          required: false
+          type: string
+
+  env:
+    configuration: Release
+    version_suffix: ${{ github.event.inputs.version_suffix }}
+  
+  jobs:
+    build-and-publish:
+      runs-on: 'ubuntu-latest'
+      permissions:
+        id-token: write  # enable GitHub OIDC token issuance for this job
+
+      steps:
+        - name: Get Source
+          uses: actions/checkout@v5
+
+        - name: Install .NET Core SDK
+          uses: actions/setup-dotnet@v5
+          with:
+            dotnet-version: |
+              8.0.x
+              9.0.x
+              10.0.x
+          
+        - name: Pack release version
+          run: dotnet pack --nologo -c ${{ env.configuration }} --version-suffix "${{ env.version_suffix }}" -o Nuget
+
+        - name: NuGet login (OIDC → temp API key)
+          uses: NuGet/login@v1
+          id: login
+          with:
+            user: ${{ secrets.NUGET_USER }}
+    
+        - name: Publish to nuget org
+          run: dotnet nuget push "*.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} -s nuget.org
+          working-directory: './Nuget'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared properties">
-    <Version Condition="'$(BuildalyzerVersion)' == ''">1.0.0</Version>
-    <Version Condition="'$(BuildalyzerVersion)' != ''">$(BuildalyzerVersion)</Version>
-    <AssemblyVersion>$(Version.Split('-')[0])</AssemblyVersion>
-    <FileVersion>$(Version.Split('-')[0])</FileVersion>
+    <VersionPrefix>7.1.0</VersionPrefix>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -58,6 +55,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" />

--- a/buildalyzer.slnx
+++ b/buildalyzer.slnx
@@ -17,6 +17,7 @@
   <Folder Name="/Solution Items/.github/workflows/">
     <File Path=".github/workflows/build.yml" />
     <File Path=".github/workflows/test-report.yml" />
+    <File Path=".github/workflows/release.yml" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Buildalyzer.Logger/Buildalyzer.Logger.csproj" />


### PR DESCRIPTION
## Add Release pipeline

This would be the "idea" of the pipeline. I'm not sure if the building will work. Locally I got errors related to net6.0 which is not installed in the pipeline currently (but it is not installed in the already present build workflow, too).

The version number is defined in the `Directory.Build.props` file for reproducability. So if one checks the nuget package for the originating commit and does a `git checkout` for it, the produced nuget should be identical to the one from nuget.org. So you would need to bump the version before a new release.

The pipeline allows to define some "version suffix" like "preview.1" which would automatically result in a nuget package versioned for example like "7.1-preview.1".

I enabled [continuousintegrationbuild](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild) as I understand that it shoud be set for official releases.

I never used [nuget trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) myself (I still use api keys for my projects). But there is some configuration needed. See the linked documentation.

Fixes: #323 