### PR TITLE
Fix binlog replay with MSBuild 18.x and normalize obsolete constructor path

### DIFF
--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -50,7 +50,7 @@ public class AnalyzerManager : IAnalyzerManager
 
     [Obsolete("Use AnalyzerManager(IOPath, AnalyzerManagerOptions) instead.")]
     public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions? options = null)
-        : this(IOPath.Parse(solutionFilePath), options) { }
+        : this(IOPath.Parse(Path.GetFullPath(solutionFilePath)), options) { }
 
     public AnalyzerManager(IOPath solutionFilePath, AnalyzerManagerOptions? options = null)
     {
@@ -100,7 +100,12 @@ public class AnalyzerManager : IAnalyzerManager
             throw new ArgumentException($"The path {binLogPath} could not be found.");
         }
 
-        BinLogReader reader = new BinLogReader();
+        // BinaryLogReplayEventSource (from Microsoft.Build) correctly handles all MSBuild 18.x
+        // event types including AssemblyLoadBuildEventArgs. The StructuredLogger.BinLogReader
+        // stops replaying mid-stream when it encounters unknown event types in newer binlogs,
+        // causing ProjectEvaluationFinishedEventArgs to never fire and leaving _evalulationResults
+        // empty, so ProjectStarted falls back to null propertiesAndItems and no results are produced.
+        var reader = new Microsoft.Build.Logging.BinaryLogReplayEventSource();
 
         using EventProcessor eventProcessor = new EventProcessor(this, null, buildLoggers, reader, true);
         reader.Replay(binLogPath);

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -83,8 +83,12 @@ internal class EventProcessor : IDisposable
         // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
         if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
         {
-            // Get the items and properties from the evaluation if needed
-            PropertiesAndItems propertiesAndItems = e.Properties is null
+            // Get the items and properties from the evaluation if needed.
+            // Treat an empty e.Properties the same as null: BinLogReader (MSBuild.StructuredLogger)
+            // creates ProjectStartedEventArgs with Properties set to a non-null but empty collection
+            // rather than null for binlog format 14+ events.  The empty collection carries no useful
+            // data, so fall back to the evaluation-phase results just as we do when Properties is null.
+            PropertiesAndItems propertiesAndItems = e.Properties is null || !e.Properties.Cast<object>().Any()
                 ? (_evalulationResults.TryGetValue(e.BuildEventContext.EvaluationId, out PropertiesAndItems evaluationResult)
                     ? evaluationResult
                     : null)

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -374,6 +374,99 @@ public class SimpleProjectsFixture
         references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
     }
 
+    /// <summary>
+    /// Regression test for the bug where ProjectReferences are empty when an analysis result
+    /// is obtained by replaying a binlog via <see cref="IAnalyzerManager.Analyze"/>.
+    ///
+    /// Root cause: <see cref="Buildalyzer.Logging.EventProcessor"/> checks
+    /// <c>e.Properties is null</c> to detect the "new-format" binlog (format 14+) and fall
+    /// back to evaluation-phase items. However, <c>BinLogReader</c> from
+    /// MSBuild.StructuredLogger creates <c>ProjectStartedEventArgs</c> with
+    /// <c>Properties</c> set to an empty non-null collection rather than <c>null</c>,
+    /// so the check always resolves to the old-format path — using the empty
+    /// <c>e.Properties</c>/<c>e.Items</c> instead of the populated evaluation results.
+    /// The fix is to treat an empty <c>e.Properties</c> the same as null.
+    /// </summary>
+    [Test]
+    public void SdkProjectWithProjectReferenceGetsReferencesFromBinaryLog(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
+        EnvironmentOptions options = new EnvironmentOptions { Preference = preference };
+        string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
+        analyzer.AddBinaryLogger(binLogPath);
+
+        try
+        {
+            // When — build to produce the binlog, then replay it
+            analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
+
+            // Then — ProjectReferences must survive the binlog round-trip
+            IEnumerable<string> references = results.First(r => r.Succeeded).ProjectReferences;
+            references.ShouldNotBeNull(log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
+        }
+        finally
+        {
+            if (File.Exists(binLogPath))
+            {
+                File.Delete(binLogPath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Regression test using the child-side <c>/bl:</c> argument (as opposed to host-side
+    /// <see cref="IProjectAnalyzer.AddBinaryLogger"/>). When the binlog is produced by passing
+    /// <c>/bl:path</c> inside <see cref="EnvironmentOptions.Arguments"/>, MSBuild writes
+    /// it from the build process itself.  Replaying that log via
+    /// <see cref="IAnalyzerManager.Analyze"/> triggers the
+    /// <c>BinLogReader</c> path in <c>EventProcessor</c> where
+    /// <c>ProjectStartedEventArgs.Properties</c> is a non-null but empty collection.
+    /// Because <see cref="Logging.EventProcessor"/> checks <c>e.Properties is null</c>
+    /// it never falls back to the evaluation-phase items, leaving
+    /// <c>ProjectReferences</c> empty.
+    /// </summary>
+    [Test]
+    public void SdkProjectWithProjectReferenceGetsReferencesFromChildSideBinaryLog(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
+        string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
+        EnvironmentOptions options = new EnvironmentOptions
+        {
+            Preference = preference
+        };
+        // Child-side binary logging: the build process itself writes the binlog
+        options.Arguments.Add($"/bl:{binLogPath}");
+
+        try
+        {
+            // When — build to produce the binlog, then replay it
+            analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
+
+            // Then — ProjectReferences must survive the child-side binlog round-trip
+            IEnumerable<string> references = results.First(r => r.Succeeded).ProjectReferences;
+            references.ShouldNotBeNull(log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
+        }
+        finally
+        {
+            if (File.Exists(binLogPath))
+            {
+                File.Delete(binLogPath);
+            }
+        }
+    }
+
     [Test]
     public void SdkProjectWithDefineContstantsGetsPreprocessorSymbols()
     {


### PR DESCRIPTION
## Summary

Three related fixes for reading binlogs produced by the .NET 10 SDK (MSBuild 18.x):

- **`AnalyzerManager.Analyze`**: replace `StructuredLogger.BinLogReader` with `Microsoft.Build.Logging.BinaryLogReplayEventSource`. The official MSBuild reader handles all 18.x event types (including `AssemblyLoadBuildEventArgs`), whereas `BinLogReader` from `MSBuild.StructuredLogger` may stop replaying mid-stream when it encounters unrecognised event types, leaving `_evalulationResults` empty so `ProjectStarted` falls back to `null` propertiesAndItems and produces no results.

- **`EventProcessor.ProjectStarted`**: treat an empty `e.Properties` collection the same as `null`. `BinLogReader` creates `ProjectStartedEventArgs` with `Properties` set to a non-null but empty collection for binlog format 14+ events, so the existing `e.Properties is null` check always fell through to the old-format path, using the empty collection instead of the populated evaluation-phase results. This left `ProjectReferences` empty after a binlog round-trip.

- **`AnalyzerManager` obsolete string constructor**: wrap the path in `Path.GetFullPath()` before passing it to `IOPath.Parse()`, restoring the behaviour of the previous `NormalizePath` implementation that was lost when `IOPath` was introduced.

Regression tests are included for the first two fixes.

## Test plan

- [ ] `SdkProjectWithProjectReferenceGetsReferencesFromBinaryLog` — builds a project with a project reference, replays the binlog, asserts `ProjectReferences` are populated
- [ ] `SdkProjectWithProjectReferenceGetsReferencesFromChildSideBinaryLog` — same but using child-side `/bl:` logging
- [ ] Existing integration test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)