### PR TITLE
Release yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+  name: 'Release'
+  
+  on:
+    workflow_dispatch:
+      inputs:
+        version_suffix:
+          description: Suffix of the version number. Can be used to create a preview package.
+          required: false
+          type: string
+
+  env:
+    configuration: Release
+    version_suffix: ${{ github.event.inputs.version_suffix }}
+  
+  jobs:
+    build-and-publish:
+      runs-on: 'ubuntu-latest'
+      permissions:
+        id-token: write  # enable GitHub OIDC token issuance for this job
+
+      steps:
+        - name: Get Source
+          uses: actions/checkout@v5
+
+        - name: Install .NET Core SDK
+          uses: actions/setup-dotnet@v5
+          with:
+            dotnet-version: |
+              8.0.x
+              9.0.x
+              10.0.x
+          
+        - name: Pack release version
+          run: dotnet pack --nologo -c ${{ env.configuration }} --version-suffix "${{ env.version_suffix }}" -o Nuget
+
+        - name: NuGet login (OIDC → temp API key)
+          uses: NuGet/login@v1
+          id: login
+          with:
+            user: ${{ secrets.NUGET_USER }}
+    
+        - name: Publish to nuget org
+          run: dotnet nuget push "*.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} -s nuget.org
+          working-directory: './Nuget'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared properties">
-    <Version Condition="'$(BuildalyzerVersion)' == ''">1.0.0</Version>
-    <Version Condition="'$(BuildalyzerVersion)' != ''">$(BuildalyzerVersion)</Version>
-    <AssemblyVersion>$(Version.Split('-')[0])</AssemblyVersion>
-    <FileVersion>$(Version.Split('-')[0])</FileVersion>
+    <VersionPrefix>7.1.0</VersionPrefix>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -59,6 +56,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
   <PropertyGroup Label="Shared properties">
     <VersionPrefix>7.1.0</VersionPrefix>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
   </ItemGroup>
   
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' OR '$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,48 +1,122 @@
 
-trigger:
-  branches:
-    include:
-      - release/*
+trigger: none
 
 pr: none
 
+parameters:
+  - name: versionSuffix
+    displayName: Version Suffix
+    type: string
+    default: ''
+  - name: allowBreakingChanges
+    displayName: Allow Breaking Changes
+    type: boolean
+    default: false
+  - name: publishPackages
+    displayName: Publish Packages To NuGet
+    type: boolean
+    default: false
+
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: ubuntu-latest
 
 variables:
-  solution: '**/*.sln'
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
-  
+  buildConfiguration: Release
+  packageOutputDirectory: $(Build.ArtifactStagingDirectory)/NuGet
+  compatibilitySuppressionsFile: $(System.DefaultWorkingDirectory)/src/Buildalyzer/CompatibilitySuppressions.xml
+  NUGET_CERT_REVOCATION_MODE: offline
+
 steps:
-- bash: |
-    tags=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))
-    echo "Latest tag on main branch: $tags"
-    echo "##vso[task.setvariable variable=myVersion;isOutput=true]$tags"
-  name: createTagVariableStep
-  displayName: 'Get Latest Tag on Main Branch'
+  - checkout: self
+    fetchDepth: 0
 
-- script: echo "The version is $(createTagVariableStep.myVersion)"
-  displayName: 'Display Version'
+  - task: UseDotNet@2
+    displayName: Install .NET SDK 6
+    inputs:
+      packageType: sdk
+      version: 6.0.x
 
-- script: |
-    dotnet restore
-    dotnet build --configuration $(buildConfiguration)
-    dotnet pack --configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory) /p:Version=$(createTagVariableStep.myVersion)
-  displayName: 'Dotnet Pack'
+  - task: UseDotNet@2
+    displayName: Install .NET SDK 8
+    inputs:
+      packageType: sdk
+      version: 8.0.x
 
-- script: dotnet nuget push "$(Build.ArtifactStagingDirectory)/**/*.nupkg" --api-key $(NuGetApiKey) --source https://api.nuget.org/v3/index.json --skip-duplicate
-  displayName: 'Push to NuGet'
+  - task: UseDotNet@2
+    displayName: Install .NET SDK 10
+    inputs:
+      packageType: sdk
+      version: 10.0.x
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'drop'
-    publishLocation: 'Container'
+  - bash: dotnet --info
+    displayName: Display .NET SDK Info
 
+  - bash: |
+      set -euo pipefail
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(System.DefaultWorkingDirectory)/src/Buildalyzer/CompatibilitySuppressions.xml'
-    ArtifactName: 'CompatibilitySuppressions'
-    publishLocation: 'Container'
+      validationArg=""
+      if [ '${{ parameters.allowBreakingChanges }}' = 'true' ]; then
+        echo "Allowing breaking changes for this release by disabling package validation."
+        validationArg="/p:EnablePackageValidation=false"
+      fi
+
+      dotnet restore buildalyzer.slnx
+      dotnet build buildalyzer.slnx -c $(buildConfiguration) --no-restore /p:ContinuousIntegrationBuild=true ${validationArg}
+    displayName: Restore And Build
+
+  - bash: |
+      set -euo pipefail
+
+      validationArg=""
+      if [ '${{ parameters.allowBreakingChanges }}' = 'true' ]; then
+        validationArg="/p:EnablePackageValidation=false"
+      fi
+
+      versionSuffixArg=""
+      if [ -n '${{ parameters.versionSuffix }}' ]; then
+        versionSuffixArg="--version-suffix ${{ parameters.versionSuffix }}"
+      fi
+
+      mkdir -p "$(packageOutputDirectory)"
+
+      projects=(
+        "src/Buildalyzer/Buildalyzer.csproj"
+        "src/Buildalyzer.Logger/Buildalyzer.Logger.csproj"
+        "src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj"
+      )
+
+      for project in "${projects[@]}"; do
+        echo "Packing ${project}"
+        dotnet pack "${project}" -c $(buildConfiguration) --no-build -o "$(packageOutputDirectory)" /p:ContinuousIntegrationBuild=true ${validationArg} ${versionSuffixArg}
+      done
+    displayName: Pack NuGet Packages
+
+  - bash: |
+      set -euo pipefail
+      if [ -z "${NuGetApiKey:-}" ]; then
+        echo "NuGetApiKey variable is required when Publish Packages To NuGet is enabled."
+        exit 1
+      fi
+    displayName: Validate NuGet Credentials
+    condition: and(succeeded(), eq('${{ parameters.publishPackages }}', 'true'))
+
+  - bash: |
+      set -euo pipefail
+      dotnet nuget push "$(packageOutputDirectory)"/*.nupkg --api-key "$(NuGetApiKey)" --source https://api.nuget.org/v3/index.json --skip-duplicate
+    displayName: Push To NuGet
+    condition: and(succeeded(), eq('${{ parameters.publishPackages }}', 'true'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish NuGet Artifacts
+    inputs:
+      PathtoPublish: $(packageOutputDirectory)
+      ArtifactName: drop
+      publishLocation: Container
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Compatibility Suppressions
+    condition: and(succeededOrFailed(), exists('$(compatibilitySuppressionsFile)'))
+    inputs:
+      PathtoPublish: $(compatibilitySuppressionsFile)
+      ArtifactName: CompatibilitySuppressions
+      publishLocation: Container

--- a/buildalyzer.slnx
+++ b/buildalyzer.slnx
@@ -17,6 +17,7 @@
   <Folder Name="/Solution Items/.github/workflows/">
     <File Path=".github/workflows/build.yml" />
     <File Path=".github/workflows/test-report.yml" />
+    <File Path=".github/workflows/release.yml" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Buildalyzer.Logger/Buildalyzer.Logger.csproj" />


### PR DESCRIPTION
Picked this up from https://github.com/Buildalyzer/Buildalyzer/pull/324
I need some feedback whether this is the right direction or not.

## Description
This PR modernizes the Azure release pipeline to match the current versioning and packaging strategy in the repository.

### What changed
 - Replaced the previous branch/tag-driven Azure pipeline with a manual release pipeline.
 - Added release parameters:
   - Version Suffix (for preview releases)
   - Allow Breaking Changes (to optionally bypass package validation/API compatibility checks)
   - Publish Packages To NuGet (safe default is off)
 - Installed required SDKs in pipeline:
   - .NET 6
   - .NET 8
   - .NET 10
 - Updated build and pack steps to:
    - use the version from Directory.Build.props
    - support optional version suffix
    - set ContinuousIntegrationBuild=true for official release builds
  - Added guarded NuGet publishing:
    - only runs when publishing is enabled
    - validates NuGetApiKey before push
  - Kept artifact publication for:
    - generated NuGet packages
    - CompatibilitySuppressions file (when present)
  - Updated Directory.Build.props so ContinuousIntegrationBuild is enabled in Azure Pipelines as well (TF_BUILD), not only in GitHub Actions.
    
### Draft next steps
 - Run both the azure release pipeline as well as the github actions and report their behaviour.
 
 Fixes: #323