### PR TITLE
Apply evaluated compile properties to CSharpCompilationOptions (fixes #342)

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerResultExtensions.cs
@@ -227,7 +227,42 @@ public static class AnalyzerResultExtensions
             {
                 Enum.TryParse(analyzerResult.GetProperty("Nullable"), ignoreCase: true, out NullableContextOptions nullable);
 
-                CompilationOptions CreateCSharpCompilationOptions() => new CSharpCompilationOptions(kind.Value, nullableContextOptions: nullable);
+                CompilationOptions CreateCSharpCompilationOptions()
+                {
+                    CSharpCompilationOptions opts = new CSharpCompilationOptions(kind.Value, nullableContextOptions: nullable);
+
+                    if (bool.TryParse(analyzerResult.GetProperty("AllowUnsafeBlocks"), out bool allowUnsafe))
+                    {
+                        opts = opts.WithAllowUnsafe(allowUnsafe);
+                    }
+
+                    if (bool.TryParse(analyzerResult.GetProperty("CheckForOverflowUnderflow"), out bool checkOverflow))
+                    {
+                        opts = opts.WithOverflowChecks(checkOverflow);
+                    }
+
+                    if (bool.TryParse(analyzerResult.GetProperty("Deterministic"), out bool deterministic))
+                    {
+                        opts = opts.WithDeterministic(deterministic);
+                    }
+
+                    // PlatformTarget is the per-project compiler target; Platform from MSBuild is the
+                    // solution platform (typically "AnyCPU"). Prefer PlatformTarget, fall back to Platform.
+                    string platform = analyzerResult.GetProperty("PlatformTarget")
+                        ?? analyzerResult.GetProperty("Platform");
+                    if (!string.IsNullOrWhiteSpace(platform)
+                        && Enum.TryParse(platform, ignoreCase: true, out Platform platformValue))
+                    {
+                        opts = opts.WithPlatform(platformValue);
+                    }
+
+                    if (int.TryParse(analyzerResult.GetProperty("WarningLevel"), out int warningLevel))
+                    {
+                        opts = opts.WithWarningLevel(warningLevel);
+                    }
+
+                    return opts;
+                }
 
                 return CreateCSharpCompilationOptions();
             }

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -75,6 +75,27 @@ public class ProjectAnalyzerExtensionsFixture
         compilationOptions.OutputKind.ShouldBe(OutputKind.DynamicallyLinkedLibrary, log.ToString());
     }
 
+    [Test]
+    public void CompilationOptionsRespectEvaluatedProperties()
+    {
+        // Given
+        SafeStringWriter log = new SafeStringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkCompilationOptionsProject\SdkCompilationOptionsProject.csproj", log);
+
+        // When
+        Workspace workspace = analyzer.GetWorkspace();
+        var compilationOptions = (Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions)workspace.CurrentSolution.Projects.First().CompilationOptions;
+
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed");
+        compilationOptions.AllowUnsafe.ShouldBeTrue(logged);
+        compilationOptions.CheckOverflow.ShouldBeTrue(logged);
+        compilationOptions.Deterministic.ShouldBeTrue(logged);
+        compilationOptions.Platform.ShouldBe(Platform.X64, logged);
+        compilationOptions.WarningLevel.ShouldBe(7, logged);
+    }
+
     [TestCase(false, 1)]
     [TestCase(true, 3)]
     public void AddsProjectReferences(bool addProjectReferences, int totalProjects)

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -78,22 +78,19 @@ public class ProjectAnalyzerExtensionsFixture
     [Test]
     public void CompilationOptionsRespectEvaluatedProperties()
     {
-        // Given
-        SafeStringWriter log = new SafeStringWriter();
-        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"projects\SdkCompilationOptionsProject\SdkCompilationOptionsProject.csproj", log);
+        using var ctx = Context.ForProject(@"SdkCompilationOptionsProject\SdkCompilationOptionsProject.csproj");
 
-        // When
-        Workspace workspace = analyzer.GetWorkspace();
+        using var workspace = ctx.Analyzer.GetWorkspace();
         var compilationOptions = (Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions)workspace.CurrentSolution.Projects.First().CompilationOptions;
 
-        // Then
-        string logged = log.ToString();
-        logged.ShouldNotContain("Workspace failed");
-        compilationOptions.AllowUnsafe.ShouldBeTrue(logged);
-        compilationOptions.CheckOverflow.ShouldBeTrue(logged);
-        compilationOptions.Deterministic.ShouldBeTrue(logged);
-        compilationOptions.Platform.ShouldBe(Platform.X64, logged);
-        compilationOptions.WarningLevel.ShouldBe(7, logged);
+        compilationOptions.Should().BeEquivalentTo(new
+        {
+            AllowUnsafe = true,
+            CheckOverflow = true,
+            Deterministic = true,
+            Platform = Platform.X64,
+            WarningLevel = 7,
+        });
     }
 
     [TestCase(false, 1)]

--- a/tests/projects/SdkCompilationOptionsProject/Class1.cs
+++ b/tests/projects/SdkCompilationOptionsProject/Class1.cs
@@ -1,0 +1,5 @@
+namespace SdkCompilationOptionsProject;
+
+public class Class1
+{
+}

--- a/tests/projects/SdkCompilationOptionsProject/Class1.cs
+++ b/tests/projects/SdkCompilationOptionsProject/Class1.cs
@@ -1,5 +1,0 @@
-namespace SdkCompilationOptionsProject;
-
-public class Class1
-{
-}

--- a/tests/projects/SdkCompilationOptionsProject/SdkCompilationOptionsProject.csproj
+++ b/tests/projects/SdkCompilationOptionsProject/SdkCompilationOptionsProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <Deterministic>true</Deterministic>

--- a/tests/projects/SdkCompilationOptionsProject/SdkCompilationOptionsProject.csproj
+++ b/tests/projects/SdkCompilationOptionsProject/SdkCompilationOptionsProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Deterministic>true</Deterministic>
+    <PlatformTarget>x64</PlatformTarget>
+    <WarningLevel>7</WarningLevel>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
### 🚀 Pull Request Template

## Description
Fixes #342. `AnalyzerResultExtensions.CreateCompilationOptions` previously constructed `CSharpCompilationOptions` with only `OutputKind` and `NullableContextOptions`, silently dropping `AllowUnsafe`, `CheckOverflow`, `Deterministic`, `Platform`, and `WarningLevel`. The fix reads `AllowUnsafeBlocks`, `CheckForOverflowUnderflow`, `Deterministic`, `PlatformTarget` (falling back to `Platform`), and `WarningLevel` from the evaluated analyzer result and applies them via the corresponding `With...` calls. Adds a `SdkCompilationOptionsProject` test fixture and a `CompilationOptionsRespectEvaluatedProperties` test asserting all five values flow through.