### PR TITLE
Fix NullReferenceException in GetWorkspace() for .slnx solutions (#350)

### DIFF
--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Buildalyzer.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 namespace Buildalyzer.Workspaces;
@@ -36,9 +37,16 @@ public static class AnalyzerManagerExtensions
             Microsoft.CodeAnalysis.SolutionInfo solutionInfo = Microsoft.CodeAnalysis.SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, solutionPath);
             workspace.AddSolution(solutionInfo);
 
-            // Sort the projects so the order that they're added to the workspace is the same order as the solution
-            List<string> projectsInOrder = [.. solution.Projects.Select(p => p.Path.ToString())];
-            results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g == p.ProjectFilePath))];
+            // Sort the projects so the order that they're added to the workspace is the same order as the solution.
+            // IOPath's equality/hash honour the file system's case sensitivity, so the lookup is robust across
+            // platforms; projects not found in the solution sort last.
+            Dictionary<IOPath, int> order = [];
+            for (int i = 0; i < solution.Projects.Length; i++)
+            {
+                order[solution.Projects[i].Path] = i;
+            }
+
+            results = [.. results.OrderBy(p => order.TryGetValue(IOPath.Parse(p.ProjectFilePath), out int index) ? index : int.MaxValue)];
         }
 
         // Add each result to the new workspace (sorted in solution order above, if we have a solution)

--- a/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
+++ b/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Build.Construction;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 namespace Buildalyzer.Workspaces;
@@ -31,14 +30,15 @@ public static class AnalyzerManagerExtensions
 
         // Create a new workspace and add the solution (if there was one)
         AdhocWorkspace workspace = manager.CreateWorkspace();
-        if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+        if (manager.Solution is { } solution)
         {
-            Microsoft.CodeAnalysis.SolutionInfo solutionInfo = Microsoft.CodeAnalysis.SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+            string solutionPath = solution.Path.ToString();
+            Microsoft.CodeAnalysis.SolutionInfo solutionInfo = Microsoft.CodeAnalysis.SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, solutionPath);
             workspace.AddSolution(solutionInfo);
 
-            // Sort the projects so the order that they're added to the workspace in the same order as the solution file
-            List<ProjectInSolution> projectsInOrder = [.. manager.SolutionFile.ProjectsInOrder];
-            results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
+            // Sort the projects so the order that they're added to the workspace is the same order as the solution
+            List<string> projectsInOrder = [.. solution.Projects.Select(p => p.Path.ToString())];
+            results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g == p.ProjectFilePath))];
         }
 
         // Add each result to the new workspace (sorted in solution order above, if we have a solution)

--- a/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/ProjectAnalyzerExtensionsFixture.cs
@@ -41,6 +41,24 @@ public class ProjectAnalyzerExtensionsFixture
         workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkFrameworkProject");
     }
 
+    [Test(Description = "Loading a workspace from a .slnx solution should not throw https://github.com/Buildalyzer/Buildalyzer/issues/350")]
+    public void LoadsSlnxSolution()
+    {
+        // Given
+        string solutionPath = GetFullPath(@"projects\SingleProject.slnx");
+        SafeStringWriter log = new SafeStringWriter();
+        AnalyzerManager manager = new AnalyzerManager(solutionPath, new AnalyzerManagerOptions { LogWriter = log });
+
+        // When
+        using var workspace = manager.GetWorkspace();
+
+        // Then
+        string logged = log.ToString();
+        logged.ShouldNotContain("Workspace failed");
+        workspace.CurrentSolution.FilePath.ShouldBe(solutionPath);
+        workspace.CurrentSolution.Projects.ShouldContain(p => p.Name == "SdkNetStandardProject");
+    }
+
     [Test]
     public async Task SupportsCompilation()
     {

--- a/tests/projects/SingleProject.slnx
+++ b/tests/projects/SingleProject.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="SdkNetStandardProject/SdkNetStandardProject.csproj" />
+</Solution>


### PR DESCRIPTION
### 🚀 Pull Request Template

## Description
This PR fixes a `NullReferenceException` thrown by `AnalyzerManager.GetWorkspace()` when the manager was loaded from a `.slnx` solution (issue #350). The cause is that `GetWorkspace()` dereferenced the obsolete `AnalyzerManager.SolutionFile`, which is `null` for `.slnx` solutions because their underlying reference is a `SolutionModel` rather than a `Microsoft.Build.Construction.SolutionFile`. The fix orders projects using the non-obsolete `SolutionInfo.Projects` (populated for both `.sln` and `.slnx`) and removes the dependency on the deprecated API. A regression test (`LoadsSlnxSolution`) plus a `SingleProject.slnx` fixture were added, and the existing `.sln` test still passes.

Closes #350